### PR TITLE
Create ResourceUtil trait so that it can easily be mixed in

### DIFF
--- a/apso/src/main/scala/eu/shiftforward/apso/io/ResourceUtil.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/io/ResourceUtil.scala
@@ -8,7 +8,7 @@ import scala.io.Source
 /**
  * Utility methods for handling resource files
  */
-object ResourceUtil {
+trait ResourceUtil {
   val defaultEncoding = "UTF-8"
 
   def getResourceURL(path: String, encoding: String = defaultEncoding): String =
@@ -20,3 +20,5 @@ object ResourceUtil {
   def getResourceAsString(path: String, encoding: String = defaultEncoding) =
     Source.fromInputStream(getResourceStream(path: String), encoding).mkString
 }
+
+object ResourceUtil extends ResourceUtil


### PR DESCRIPTION
Self-descriptive. This is useful for mixing in `TestHelper` traits for example.