### PR TITLE
Fix X-Forwarded-For modifcation in proxy requests

### DIFF
--- a/apso/src/main/scala/eu/shiftforward/apso/spray/ClientIPDirectives.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/spray/ClientIPDirectives.scala
@@ -2,12 +2,12 @@ package eu.shiftforward.apso.spray
 
 import spray.http.RemoteAddress
 import spray.routing.Directive1
-import spray.routing.directives.{ BasicDirectives, MiscDirectives }
+import spray.routing.directives.{ BasicDirectives, HeaderDirectives, MiscDirectives }
 
 /**
  * Directives to extract the value of the Client IP.
  */
-trait ClientIPDirectives extends BasicDirectives with MiscDirectives {
+trait ClientIPDirectives extends BasicDirectives with HeaderDirectives with MiscDirectives {
 
   /**
    * Directive extracting the RemoteAddress of the client from either the X-Forwarded-For, Remote-Address or X-Real-IP header
@@ -23,5 +23,10 @@ trait ClientIPDirectives extends BasicDirectives with MiscDirectives {
    * (in that order of priority).
    */
   def optionalRawClientIP: Directive1[Option[String]] =
-    optionalClientIP.map(_.map(_.value))
+    // This isn't implemented using spray's `clientIp` directive since it is not guaranteed that we
+    // have a valid `RemoteAddress` as the header value (e.g. due to IP anonymization).
+    headerValuePF { case h if h.is("x-forwarded-for") => h.value.split(",").headOption } |
+      headerValuePF { case h if h.is("remote-address") => Option(h.value) } |
+      headerValuePF { case h if h.is("x-real-ip") => Option(h.value) } |
+      provide(None)
 }

--- a/apso/src/main/scala/eu/shiftforward/apso/spray/ClientIPDirectives.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/spray/ClientIPDirectives.scala
@@ -1,22 +1,27 @@
 package eu.shiftforward.apso.spray
 
+import spray.http.RemoteAddress
 import spray.routing.Directive1
-import spray.routing.directives.{ BasicDirectives, HeaderDirectives }
+import spray.routing.directives.{ BasicDirectives, MiscDirectives }
 
 /**
  * Directives to extract the value of the Client IP.
  */
-trait ClientIPDirectives extends BasicDirectives with HeaderDirectives {
+trait ClientIPDirectives extends BasicDirectives with MiscDirectives {
+
+  /**
+   * Directive extracting the RemoteAddress of the client from either the X-Forwarded-For, Remote-Address or X-Real-IP header
+   * (in that order of priority).
+   */
+  def optionalClientIP: Directive1[Option[RemoteAddress]] =
+    clientIP.map(Option(_)).recoverPF {
+      case Nil => provide(None)
+    }
 
   /**
    * Directive extracting the raw IP of the client from either the X-Forwarded-For, Remote-Address or X-Real-IP header
    * (in that order of priority).
    */
   def optionalRawClientIP: Directive1[Option[String]] =
-    // This isn't implemented using spray's `clientIp` directive since it is not guaranteed that we
-    // have a valid `RemoteAddress` as the header value (e.g. due to IP anonymization).
-    headerValuePF { case h if h.is("x-forwarded-for") => Some(h.value) } |
-      headerValuePF { case h if h.is("remote-address") => Some(h.value) } |
-      headerValuePF { case h if h.is("x-real-ip") => Some(h.value) } |
-      provide(None)
+    optionalClientIP.map(_.map(_.value))
 }

--- a/apso/src/main/scala/eu/shiftforward/apso/spray/ProxySupport.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/spray/ProxySupport.scala
@@ -52,7 +52,7 @@ trait ProxySupport extends ClientIPDirectives {
   }
 
   private val optionalRemoteAddress: Directive1[Option[RemoteAddress]] =
-    headerValuePF { case `Remote-Address`(address) ⇒ Some(address) } | provide(None)
+    headerValuePF { case `Remote-Address`(address) => Some(address) } | provide(None)
 
   def proxyTo(uri: Uri)(implicit system: ActorSystem): Route = {
     optionalRemoteAddress { ip =>

--- a/apso/src/main/scala/eu/shiftforward/apso/spray/ProxySupport.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/spray/ProxySupport.scala
@@ -3,9 +3,10 @@ package eu.shiftforward.apso.spray
 import akka.actor.ActorSystem
 import akka.io.IO
 import spray.can.Http
-import spray.http.{ HttpHeader, HttpRequest, Uri }
-import spray.http.HttpHeaders.`X-Forwarded-For`
-import spray.routing.{ RequestContext, Route }
+import spray.http.{ HttpHeader, HttpRequest, RemoteAddress, Uri }
+import spray.http.HttpHeaders.{ `Remote-Address`, `X-Forwarded-For` }
+import spray.routing.directives.HeaderDirectives._
+import spray.routing.{ Directive1, RequestContext, Route }
 
 /**
  * Allows to proxy a request to another URI.
@@ -29,15 +30,32 @@ trait ProxySupport extends ClientIPDirectives {
     ctx => transport.tell(f(ctx), ctx.responder)
   }
 
-  private def getHeaders(ip: Option[String], headers: List[HttpHeader] = Nil) = {
+  private def getHeaders(ip: Option[RemoteAddress], headers: List[HttpHeader] = Nil) = {
     // filter `Host` header
     val hs = headers.filterNot(header => header.is("host"))
     // add `X-Forwarded-For` header
-    ip.fold(hs)(`X-Forwarded-For`(_) :: hs)
+    ip.fold(hs)(addForwardedFor(_, hs))
   }
 
+  private def addForwardedFor(ip: RemoteAddress, headers: List[HttpHeader]): List[HttpHeader] = {
+    headers match {
+      case Nil =>
+        // No `X-Forwarded-For` found in headers, so just add the new one
+        `X-Forwarded-For`(ip) :: Nil
+
+      case `X-Forwarded-For`(ips) :: tail =>
+        `X-Forwarded-For`(ips :+ ip) :: tail
+
+      case notForwardedFor :: tail =>
+        notForwardedFor :: addForwardedFor(ip, tail)
+    }
+  }
+
+  private val optionalRemoteAddress: Directive1[Option[RemoteAddress]] =
+    headerValuePF { case `Remote-Address`(address) ⇒ Some(address) } | provide(None)
+
   def proxyTo(uri: Uri)(implicit system: ActorSystem): Route = {
-    optionalRawClientIP { ip =>
+    optionalRemoteAddress { ip =>
       sending(ctx => ctx.request.copy(
         uri = uri,
         headers = getHeaders(ip, ctx.request.headers)))
@@ -45,7 +63,7 @@ trait ProxySupport extends ClientIPDirectives {
   }
 
   def proxyToUnmatchedPath(uri: Uri)(implicit system: ActorSystem): Route = {
-    optionalRawClientIP { ip =>
+    optionalRemoteAddress { ip =>
       sending { ctx =>
         ctx.request.copy(
           uri = uri.withPath(uri.path.++(ctx.unmatchedPath)).withQuery(ctx.request.uri.query),

--- a/apso/src/test/scala/eu/shiftforward/apso/spray/ProxySupportSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/spray/ProxySupportSpec.scala
@@ -1,7 +1,6 @@
 package eu.shiftforward.apso.spray
 
 import scala.concurrent.duration._
-
 import akka.actor.{ Actor, Props }
 import akka.io.IO
 import akka.pattern.ask
@@ -13,6 +12,7 @@ import spray.http.{ HttpRequest, HttpResponse, Uri }
 import spray.routing._
 import spray.testkit.Specs2RouteTest
 import spray.util._
+import spray.http.HttpHeaders._
 
 class ProxySupportSpec
     extends Specification
@@ -23,6 +23,9 @@ class ProxySupportSpec
   trait MockServer extends Scope {
 
     def serverPath = "remote-proxy"
+    def serverResponse(req: HttpRequest): HttpResponse = {
+      HttpResponse(entity = req.uri.toRelative.toString)
+    }
 
     val (interface, port) = Utils.temporaryServerHostnameAndPort()
 
@@ -31,7 +34,7 @@ class ProxySupportSpec
         new Actor {
           def receive = {
             case x: Http.Connected => sender ! Http.Register(self)
-            case x: HttpRequest => sender ! HttpResponse(entity = x.uri.toRelative.toString)
+            case req: HttpRequest => sender ! serverResponse(req)
             case _: Http.ConnectionClosed => // ignore
           }
         }
@@ -91,6 +94,43 @@ class ProxySupportSpec
         responseAs[String] must be_==("/remote-proxy/other/path/parts?foo=bar")
       }
     }
+
+    "Modify the `X-Forwarded-For` header" in new MockServer {
+
+      override def serverResponse(req: HttpRequest) = {
+        val forwardedForIps = req.headers.collectFirst {
+          case `X-Forwarded-For`(ips) => ips
+        }.getOrElse(Seq.empty)
+        HttpResponse(entity = forwardedForIps.mkString(", "))
+      }
+
+      "add `X-Forwarded-For` if request has `Remote-Address`" in {
+        Get("/get-path-proxied").withHeaders(`Remote-Address`("127.0.0.1")) ~> routes ~> check {
+          status == OK
+          responseAs[String] must be_==("127.0.0.1")
+        }
+      }
+
+      "update existing `X-Forwarded-For`" in {
+        Get("/get-path-proxied").withHeaders(`Remote-Address`("127.0.0.1"), `X-Forwarded-For`("127.0.0.2")) ~> routes ~> check {
+          status == OK
+          responseAs[String] must be_==("127.0.0.2, 127.0.0.1")
+        }
+
+        Get("/get-path-proxied").withHeaders(`X-Forwarded-For`("127.0.0.2")) ~> routes ~> check {
+          status == OK
+          responseAs[String] must be_==("127.0.0.2")
+        }
+      }
+
+      "do not add `X-Forwarded-For` if no `Remote-Address`" in {
+        Get("/get-path-proxied") ~> routes ~> check {
+          status == OK
+          responseAs[String] must be_==("a")
+        }
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
A duplicated `X-Forwarded-For` header was being added in proxy requests if that header already existed.

This PR also simplifies the directives in `ClientIPDirectives`.