### PR TITLE
Daemonize S3Bucket.TransferManager threadpool

### DIFF
--- a/apso/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
@@ -68,6 +68,7 @@ class S3Bucket(val bucketName: String,
       // to make sure that threads are daemonized. This could be problematic, e.g. shutting down the
       // JVM before a transfer has finished, although this won't happen in our use case since we
       // always wait for transfers to finish.
+      // (This code is copy-pasted from the AWS SDK with the addition of the `setDaemon` call).
       val executor = Executors.newFixedThreadPool(10, new ThreadFactory() {
         var threadCount = 1;
         def newThread(r: Runnable) = {


### PR DESCRIPTION
This PR changes the default thread pool executor of `S3Bucket`'s `TransferManager` to use daemon threads.

Currently the `FileDescriptor` does not provide any method to "close" the file and free any underlying resources (and also on `S3Bucket`). Using the default `TransferManager` thread pool would leave the JVM hanging waiting for those threads to finish.