### PR TITLE
Fix handling of nested configs in toMap method

### DIFF
--- a/apso/src/test/scala/eu/shiftforward/apso/config/ConfigImplicitsSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/config/ConfigImplicitsSpec.scala
@@ -58,7 +58,7 @@ class ConfigImplicitsSpec extends Specification {
         map-nested {
           a {
             b {
-              e = "4"
+              "\ne" = "4"
               f = "7"
             }
             c = "5"
@@ -183,7 +183,7 @@ class ConfigImplicitsSpec extends Specification {
       config.getMap[String]("map-escape") must beEqualTo(
         Map("a" -> "a", "(a,{} b. c)" -> "abc", "x{}" -> "abc", "_()#..!" -> "a"))
       config.getMap[String]("map-nested") must beEqualTo(
-        Map("a.b.e" -> "4", "a.b.f" -> "7", "a.c" -> "5", "d" -> "6"))
+        Map("a.b.\ne" -> "4", "a.b.f" -> "7", "a.c" -> "5", "d" -> "6"))
     }
 
     "allow extracting configurations returning an option of a map" in {

--- a/apso/src/test/scala/eu/shiftforward/apso/config/ConfigImplicitsSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/config/ConfigImplicitsSpec.scala
@@ -55,6 +55,17 @@ class ConfigImplicitsSpec extends Specification {
           "_()#..!" = "a"
         }
 
+        map-nested {
+          a {
+            b {
+              e = "4"
+              f = "7"
+            }
+            c = "5"
+          }
+          d = "6"
+        }
+
         "config.com" {
           "site.pt" = "ok"
         }
@@ -171,6 +182,8 @@ class ConfigImplicitsSpec extends Specification {
       config.getMap[Int]("num-map") must beEqualTo(Map("k1" -> 1, "k2" -> 2))
       config.getMap[String]("map-escape") must beEqualTo(
         Map("a" -> "a", "(a,{} b. c)" -> "abc", "x{}" -> "abc", "_()#..!" -> "a"))
+      config.getMap[String]("map-nested") must beEqualTo(
+        Map("a.b.e" -> "4", "a.b.f" -> "7", "a.c" -> "5", "d" -> "6"))
     }
 
     "allow extracting configurations returning an option of a map" in {


### PR DESCRIPTION
This PR makes the implementation of the `toMap` method of `ApsoConfig` properly handle nested config objects, joining the keys with dots. This is consistent with the previous behaviour of the `toMap` method (from v0.6), while retaining the current way of handling escaped strings.