### PR TITLE
Fix/config to map

### DIFF
--- a/apso/src/main/scala/eu/shiftforward/apso/config/LazyConfigFactory.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/config/LazyConfigFactory.scala
@@ -170,7 +170,7 @@ object LazyConfigFactory {
   }
 
   private[this] class WithSettingsBuilder(baseConfig: Config, settings: Config) extends Builder {
-    val validationProblems = settings.toMap[Unit].keys.toSeq.collect {
+    val validationProblems = settings.toFlattenedMap[Unit].keys.toSeq.collect {
       case path if baseConfig.hasPath(path) =>
         new ConfigException.ValidationProblem(path, settings.origin(),
           "Settings added with .withSettings() must not override existing ones")

--- a/apso/src/test/scala/eu/shiftforward/apso/config/ConfigImplicitsSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/config/ConfigImplicitsSpec.scala
@@ -243,7 +243,7 @@ class ConfigImplicitsSpec extends Specification {
       config.getListOption("f") must throwAn[Exception]
     }
 
-    "allow extracting configurations returnin a map" in {
+    "allow extracting configurations returning a map" in {
       config.getMap[String]("map") must beEqualTo(Map("k1" -> "v1", "k2" -> "v2"))
       config.getMap[Int]("num-map") must beEqualTo(Map("k1" -> 1, "k2" -> 2))
       config.getMap[String]("map-escape") must beEqualTo(


### PR DESCRIPTION
This changes how `toMap` handles the map keys building.

Before this change, it was possible for the method to create keys that had no correspondence in a path on the original config object. This happened because all the path segments were unquoted even if containing special characters.

A consequence of this behavior is that calling `.hasPath` on the original config object using one the produced map keys could throw an exception.

This PR uses `ConfigUtil.joinPath` to correctly quote all the path segments and join them to create the final map keys, thus guaranteeing that all the produced map keys work as paths for the original config object.

EDIT: as @jcazevedo commented, a previous implementation already existed. I've reverted back to the old implementation