### PR TITLE
Add new receiveAllOfInOrder matcher

### DIFF
--- a/apso-testkit/src/main/scala/eu/shiftforward/apso/actor/ActorMatchers.scala
+++ b/apso-testkit/src/main/scala/eu/shiftforward/apso/actor/ActorMatchers.scala
@@ -56,4 +56,12 @@ trait ActorMatchers extends SpecificationLike {
   def receiveAllOf(max: FiniteDuration, msg: Any*): Matcher[TestKitBase] = { probe: TestKitBase =>
     probe.expectMsgAllOf(max, msg: _*) must not(throwAn[Exception])
   }
+
+  def receiveAllOfInOrder(msgList: Any*): Matcher[TestKitBase] = { probe: TestKitBase =>
+    msgList.foreach { msg => probe.expectMsg(msg) } must not(throwAn[Exception])
+  }
+
+  def receiveAllOfInOrder(max: FiniteDuration, msgList: Any*): Matcher[TestKitBase] = { probe: TestKitBase =>
+    msgList.foreach { msg => probe.expectMsg(max, msg) } must not(throwAn[Exception])
+  }
 }


### PR DESCRIPTION
Add new `receiveAllOfInOrder` methods to match against a list of messages in the specified order.