### PR TITLE
Remove PureConfig integration and dependency

### DIFF
--- a/apso/src/main/scala/eu/shiftforward/apso/config/Implicits.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/config/Implicits.scala
@@ -2,7 +2,6 @@ package eu.shiftforward.apso.config
 
 import com.typesafe.config._
 import com.github.nscala_time.time.Imports.{ Duration => _, _ }
-import pureconfig._
 
 import scala.annotation.implicitNotFound
 import scala.concurrent.duration._
@@ -329,9 +328,6 @@ object Implicits extends BasicConfigReaders with ExtendedConfigReaders {
         value <- Try(conf.getConfig(key)).toOption
       } yield { key -> value }).toMap
     }
-
-    def to[T: ConfigConvert]: Try[T] =
-      loadConfig[T](conf)
   }
 }
 

--- a/apso/src/test/scala/eu/shiftforward/apso/config/ConfigImplicitsSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/config/ConfigImplicitsSpec.scala
@@ -323,11 +323,5 @@ class ConfigImplicitsSpec extends Specification {
         confEscape.hasPath(k) must beTrue
       }
     }
-
-    "allow converting configurations into type which have the ConfigConvert typeclass" in {
-      case class Foo(k1: String, k2: String)
-      config.getConfig("map").to[Foo] must beSuccessfulTry.withValue(Foo("v1", "v2"))
-      config.getConfig("map").to[Map[String, String]] must beSuccessfulTry.withValue(Map("k1" -> "v1", "k2" -> "v2"))
-    }
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -20,7 +20,6 @@ object ProjectBuild extends Build {
       "com.amazonaws"                  % "aws-java-sdk-ec2"          % "1.11.27"        % "provided",
       "com.amazonaws"                  % "aws-java-sdk-s3"           % "1.11.27"        % "provided",
       "com.chuusai"                   %% "shapeless"                 % "2.3.1",
-      "com.github.melrief"            %% "pureconfig"                % "0.2.2",
       "com.github.nscala-time"        %% "nscala-time"               % "2.12.0"         % "provided",
       "com.hierynomus"                 % "sshj"                      % "0.17.2",
       "com.j256.simplejmx"             % "simplejmx"                 % "1.12",


### PR DESCRIPTION
This PR removes the PureConfig integration and dependency. Sorry for reverting #11, but the [PureConfig branch](https://github.com/melrief/pureconfig/pull/28) I'm currently working with already provides the method I've added here.