### PR TITLE
Streaming upload to file descriptors

### DIFF
--- a/apso/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
@@ -152,6 +152,23 @@ class S3Bucket(val bucketName: String,
   }.isDefined
 
   /**
+   * Pushes a given `InputStream` to the location specified by `key` in the bucket.
+   *
+   * @param key the remote pathname for the file
+   * @param inputStream the `InputStream` to push
+   * @param length the content lenght (setting this to `None` can impact performance
+   * @return true if the push was successful, false otherwise.
+   */
+  def push(key: String, inputStream: InputStream, length: Option[Long]): Boolean = retry {
+    log.info("Pushing to 's3://{}/{}'", bucketName: Any, key: Any)
+    val metadata = new ObjectMetadata()
+    length.foreach(metadata.setContentLength)
+    transferManager
+      .upload(new PutObjectRequest(bucketName, sanitizeKey(key), inputStream, metadata))
+      .waitForUploadResult()
+  }.isDefined
+
+  /**
    * Deletes the file in the location specified by `key` in the bucket.
    *
    * @param key the remote pathname for the file

--- a/apso/src/main/scala/eu/shiftforward/apso/io/FileDescriptor.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/io/FileDescriptor.scala
@@ -52,6 +52,16 @@ trait FileDescriptor {
   def upload(localTarget: LocalFileDescriptor): Boolean
 
   /**
+   * Uploads an input stream to this file's location.
+   * The target must point to a file.
+   *
+   * @param inputStream the input stream that should be uploaded.
+   * @param length the input stream length (leaving this as `None` can have performance implications)
+   * @return `true` if the upload was successful, `false` otherwise.
+   */
+  def upload(inputStream: InputStream, length: Option[Long]): Boolean
+
+  /**
    * Returns an input stream for the contents of this file.
    * @return an input stream for the contents of this file.
    */

--- a/apso/src/main/scala/eu/shiftforward/apso/io/LocalFileDescriptor.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/io/LocalFileDescriptor.scala
@@ -97,6 +97,25 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
     }
   }
 
+  def upload(inputStream: InputStream, length: Option[Long]): Boolean = {
+    if (isDirectory) {
+      throw new Exception("File descriptor points to a directory")
+    } else {
+
+      parent().mkdirs()
+
+      val result = Try(Files.copy(inputStream, normalizedPath,
+        StandardCopyOption.REPLACE_EXISTING))
+
+      result match {
+        case Success(_) =>
+        case Failure(ex) => log.warn("File copy failed ({})", ex.toString)
+      }
+
+      result.isSuccess
+    }
+  }
+
   def stream() = new FileInputStream(file)
 
   override def list: Iterator[LocalFileDescriptor] = {

--- a/apso/src/main/scala/eu/shiftforward/apso/io/S3FileDescriptor.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/io/S3FileDescriptor.scala
@@ -1,12 +1,14 @@
 package eu.shiftforward.apso.io
 
+import java.io.InputStream
+
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.services.s3.model.S3ObjectSummary
 import com.typesafe.config.Config
-import eu.shiftforward.apso.Logging
-import eu.shiftforward.apso.aws.{ SerializableAWSCredentials, S3Bucket }
-import eu.shiftforward.apso.config.FileDescriptorCredentials
 
+import eu.shiftforward.apso.Logging
+import eu.shiftforward.apso.aws.{ S3Bucket, SerializableAWSCredentials }
+import eu.shiftforward.apso.config.FileDescriptorCredentials
 import scala.collection.concurrent.TrieMap
 
 case class S3FileDescriptor(bucket: S3Bucket,
@@ -55,6 +57,14 @@ case class S3FileDescriptor(bucket: S3Bucket,
       throw new Exception("File descriptor points to a directory")
     } else {
       bucket.push(builtPath, localTarget.file)
+    }
+  }
+
+  def upload(inputStream: InputStream, length: Option[Long]): Boolean = {
+    if (isDirectory) {
+      throw new Exception("File descriptor points to a directory")
+    } else {
+      bucket.push(builtPath, inputStream, length)
     }
   }
 

--- a/apso/src/test/scala/eu/shiftforward/apso/io/LocalFileDescriptorSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/io/LocalFileDescriptorSpec.scala
@@ -1,10 +1,10 @@
 package eu.shiftforward.apso.io
 
-import java.io.File
+import java.io.{ File, InputStream }
 import java.nio.file.Files
 import java.util.UUID
-import org.specs2.mutable.Specification
 
+import org.specs2.mutable.Specification
 import scala.io.Source
 import scala.util.Try
 
@@ -142,17 +142,34 @@ class LocalFileDescriptorSpec extends Specification {
     }
 
     "Upload file correctly to a file" in {
-      val fd1 = LocalFileDescriptor("/tmp") / randomFolder / randomString
-      val fd2 = LocalFileDescriptor("/tmp") / randomFolder / randomString
+      "From another file" in {
+        val fd1 = LocalFileDescriptor("/tmp") / randomFolder / randomString
+        val fd2 = LocalFileDescriptor("/tmp") / randomFolder / randomString
 
-      val file1 = fd1 / "one"
-      file1.write("hello world")
+        val file1 = fd1 / "one"
+        file1.write("hello world")
 
-      val file2 = fd2 / "two"
-      file2.exists must beFalse
+        val file2 = fd2 / "two"
+        file2.exists must beFalse
 
-      file2.upload(file1)
-      file2.readString must beEqualTo("hello world")
+        file2.upload(file1)
+        file2.readString must beEqualTo("hello world")
+      }
+
+      "From an InputStream" in {
+        val fd = LocalFileDescriptor("/tmp") / randomFolder / randomString
+
+        val inputStream = new InputStream {
+          val buffer = "hello world".iterator.map(_.toInt)
+          override def read(): Int = if (buffer.isEmpty) -1 else buffer.next()
+        }
+
+        val file = fd / "two"
+        file.exists must beFalse
+
+        file.upload(inputStream, None)
+        file.readString must beEqualTo("hello world")
+      }
     }
 
     "Do not upload file to a directory" in {


### PR DESCRIPTION
Adds a new `upload` method to the `FileDescriptor` that receives an `InputStream` instead of a `File`. This way, it's possible to upload data that is only stored in-memory.

Unfortunately, the S3 backend pretty much requires that the file length is known a priori, otherwise it will download the whole file to memory to find out its size. Also, the SFTP backend also seems to require the file size for logging purposes.

Therefore, this new method also receives an optional `length` attribute that it is recommended to be defined for streams with known length.