### PR TITLE
akka-http reverse proxy

### DIFF
--- a/apso-testkit/src/main/scala/eu/shiftforward/apso/akka/http/Specs2RouteTest.scala
+++ b/apso-testkit/src/main/scala/eu/shiftforward/apso/akka/http/Specs2RouteTest.scala
@@ -1,0 +1,18 @@
+package eu.shiftforward.apso.akka.http
+
+import _root_.akka.http.scaladsl.testkit.{ RouteTest, TestFrameworkInterface }
+import org.specs2.execute.{ Failure, FailureException }
+
+// until akka-http gets support
+trait Specs2Interface extends TestFrameworkInterface {
+  // def cleanUp(): Unit
+
+  // from spray-testkit
+  def failTest(msg: String): Nothing = {
+    val trace = new Exception().getStackTrace.toList
+    val fixedTrace = trace.drop(trace.indexWhere(_.getClassName.startsWith("org.specs2")) - 1)
+    throw FailureException(Failure(msg, stackTrace = fixedTrace))
+  }
+}
+
+trait Specs2RouteTest extends RouteTest with Specs2Interface

--- a/apso/src/main/scala/eu/shiftforward/apso/NamedActorLogging.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/NamedActorLogging.scala
@@ -1,7 +1,7 @@
 package eu.shiftforward.apso
 
-import akka.actor.{ Actor, ActorLogging }
-import akka.event.{ Logging => AkkaLogging }
+import _root_.akka.actor.{ Actor, ActorLogging }
+import _root_.akka.event.{ Logging => AkkaLogging }
 
 trait NamedActorLogging extends ActorLogging { this: Actor =>
   override lazy val log = AkkaLogging(context.system.eventStream, self.path.toString)

--- a/apso/src/main/scala/eu/shiftforward/apso/akka/http/ClientIPDirectives.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/akka/http/ClientIPDirectives.scala
@@ -1,0 +1,32 @@
+package eu.shiftforward.apso.akka.http
+
+import akka.http.scaladsl.model.RemoteAddress
+import akka.http.scaladsl.server.Directive1
+import akka.http.scaladsl.server.Directives._
+
+/**
+ * Directives to extract the value of the clients' IP addresses.
+ */
+trait ClientIPDirectives {
+
+  /**
+   * Directive extracting the remote address of the client from the `X-Forwarded-For`, `Remote-Address` or `X-Real-IP`
+   * headers (in that order).
+   */
+  def optionalClientIP: Directive1[Option[RemoteAddress]] =
+    extractClientIP.map(Option(_)).recoverPF {
+      case Nil => provide(None)
+    }
+
+  /**
+   * Directive extracting the raw IP of the client from either the `X-Forwarded-For`, `Remote-Address` or `X-Real-IP`
+   * headers (in that order).
+   */
+  // This isn't implemented using spray's `clientIp` directive since it is not guaranteed that we
+  // have a valid `RemoteAddress` as the header value (e.g. due to IP anonymization).
+  def optionalRawClientIP: Directive1[Option[String]] =
+    headerValuePF { case h if h.is("x-forwarded-for") => h.value.split(",").headOption } |
+      headerValuePF { case h if h.is("remote-address") => Option(h.value) } |
+      headerValuePF { case h if h.is("x-real-ip") => Option(h.value) } |
+      provide(None)
+}

--- a/apso/src/main/scala/eu/shiftforward/apso/akka/http/ProxySupport.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/akka/http/ProxySupport.scala
@@ -1,0 +1,149 @@
+package eu.shiftforward.apso.akka.http
+
+import scala.concurrent.{ Future, Promise }
+import scala.util.{ Failure, Success, Try }
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{ `Remote-Address`, `X-Forwarded-For` }
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.RouteResult.Complete
+import akka.http.scaladsl.server.{ Directive1, Route, RouteResult }
+import akka.stream.QueueOfferResult.{ Dropped, Enqueued, QueueClosed, Failure => OfferFailure }
+import akka.stream.scaladsl.{ Keep, Sink, Source }
+import akka.stream.{ Materializer, OverflowStrategy }
+
+import eu.shiftforward.apso.Logging
+
+/**
+ * Adds proxy to akka-http services to proxy requests to other hosts.
+ *
+ * If the target server is known in advance, a `Proxy` object can be created. This internally materializes a flow that
+ * is continuously active and ready to route incoming requests.
+ *
+ * For one-off requests or requests to previously unknown hosts, this trait defines two routes:
+ * - `proxySingleTo` takes the original request and proxies it to the proxy URI;
+ * - `proxySingleToUnmatchedPath` copies only the unmatched path from the original URI, and adds it to the path of the
+ * proxy URI.
+ */
+trait ProxySupport extends ClientIPDirectives {
+
+  private[this] def getHeaders(ip: Option[RemoteAddress], headers: List[HttpHeader] = Nil) = {
+    // filter `Host` and `Timeout-Access` headers
+    val hs = headers.filterNot(header => header.is("host") || header.is("timeout-access"))
+    // add `X-Forwarded-For` header
+    ip.fold(hs)(addForwardedFor(_, hs))
+  }
+
+  private[this] def addForwardedFor(ip: RemoteAddress, headers: List[HttpHeader]): List[HttpHeader] = {
+    headers match {
+      case Nil =>
+        // No `X-Forwarded-For` found in headers, so just add the new one
+        `X-Forwarded-For`(ip) :: Nil
+
+      case `X-Forwarded-For`(ips) :: tail =>
+        `X-Forwarded-For`(ips :+ ip) :: tail
+
+      case notForwardedFor :: tail =>
+        notForwardedFor :: addForwardedFor(ip, tail)
+    }
+  }
+
+  private[this] val optionalRemoteAddress: Directive1[Option[RemoteAddress]] =
+    headerValuePF { case `Remote-Address`(address) => Some(address) } | provide(None)
+
+  /**
+   * Proxies a single request to a destination URI.
+   *
+   * @param uri the target URI
+   * @return a route that handles requests by proxying them to the given URI.
+   */
+  def proxySingleTo(uri: Uri): Route = {
+    extractActorSystem { implicit system =>
+      extractMaterializer { implicit mat =>
+        optionalRemoteAddress { ip =>
+          ctx =>
+            val req = ctx.request.copy(
+              uri = uri,
+              headers = getHeaders(ip, ctx.request.headers.toList))
+
+            import system.dispatcher
+            Http(system).singleRequest(req).map(Complete.apply)
+        }
+      }
+    }
+  }
+
+  /**
+   * Proxies a single request to a destination base URI. The target URI is created by concatenating the base URI with
+   * the unmatched path.
+   *
+   * @param uri the target base URI
+   * @return a route that handles requests by proxying them to the given URI.
+   */
+  def proxySingleToUnmatchedPath(uri: Uri): Route = {
+    extractActorSystem { implicit system =>
+      extractMaterializer { implicit mat =>
+        optionalRemoteAddress { ip =>
+          ctx =>
+            val req = ctx.request.copy(
+              uri = uri.withPath(uri.path ++ ctx.unmatchedPath).withQuery(ctx.request.uri.query()),
+              headers = getHeaders(ip, ctx.request.headers.toList))
+
+            import system.dispatcher
+            Http(system).singleRequest(req).map(Complete.apply)
+        }
+      }
+    }
+  }
+
+  /**
+   * A representation of a reverse proxy for a remote host. This class internally materializes a flow that is
+   * continuously active and ready to route incoming requests.
+   *
+   * @param host the target host
+   * @param port the target port
+   * @param reqQueueSize the maximum size of the queue of pending backend requests
+   */
+  class Proxy(host: String, port: Int, reqQueueSize: Int = 65536)(implicit system: ActorSystem, mat: Materializer)
+      extends Logging {
+
+    import system.dispatcher
+
+    private[this] lazy val source = Source.queue[(HttpRequest, Promise[RouteResult])](
+      reqQueueSize, OverflowStrategy.dropNew)
+
+    private[this] lazy val flow = Http().cachedHostConnectionPool[Promise[RouteResult]](host, port)
+
+    private[this] lazy val sink = Sink.foreach[(Try[HttpResponse], Promise[RouteResult])] {
+      case ((Success(resp), p)) => p.success(Complete(resp))
+      case ((Failure(e), p)) => p.failure(e)
+    }
+
+    private[this] lazy val queue = source.via(flow).toMat(sink)(Keep.left).run()
+
+    /**
+     * Proxies a request to a destination URI.
+     *
+     * @param uri the target URI
+     * @return a route that handles requests by proxying them to the given URI.
+     */
+    def proxyTo(uri: Uri): Route = {
+      optionalRemoteAddress { ip =>
+        ctx =>
+          val req = ctx.request.copy(uri = uri, headers = getHeaders(ip, ctx.request.headers.toList))
+          val promise = Promise[RouteResult]()
+
+          queue.offer(req -> promise).flatMap {
+            case Enqueued => promise.future
+            case OfferFailure(ex) => Future.failed(new RuntimeException("Queue offering failed", ex))
+            case QueueClosed => Future.failed(new RuntimeException("Queue is completed before call!?"))
+            case Dropped =>
+              log.warn("Request queue for {}:{} is full", host, port)
+              Future.successful(Complete(HttpResponse(StatusCodes.ServiceUnavailable)))
+          }
+      }
+    }
+  }
+}

--- a/apso/src/main/scala/eu/shiftforward/apso/akka/http/ProxySupport.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/akka/http/ProxySupport.scala
@@ -99,21 +99,21 @@ trait ProxySupport extends ClientIPDirectives {
     }
   }
 
+  private[this] lazy val defaultQueueSize =
+    ConfigFactory.load.getInt("akka.http.host-connection-pool.max-open-requests")
+
   /**
    * A representation of a reverse proxy for a remote host. This class internally materializes a flow that is
    * continuously active and ready to route incoming requests.
    *
    * @param host the target host
    * @param port the target port
-   * @param customQueueSize the maximum size of the queue of pending backend requests
+   * @param reqQueueSize the maximum size of the queue of pending backend requests
    */
-  class Proxy(host: String, port: Int, customQueueSize: Option[Int] = None)(implicit system: ActorSystem, mat: Materializer)
+  class Proxy(host: String, port: Int, reqQueueSize: Int = defaultQueueSize)(implicit system: ActorSystem, mat: Materializer)
       extends Logging {
 
     import system.dispatcher
-
-    private[this] val reqQueueSize = customQueueSize.getOrElse(
-      ConfigFactory.load.getInt("akka.http.host-connection-pool.max-open-requests"))
 
     private[this] lazy val source = Source.queue[(HttpRequest, Promise[RouteResult])](
       reqQueueSize, OverflowStrategy.dropNew)

--- a/apso/src/test/scala/eu/shiftforward/apso/akka/http/ProxySupportSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/akka/http/ProxySupportSpec.scala
@@ -1,0 +1,116 @@
+package eu.shiftforward.apso.akka.http
+
+import java.net.InetAddress
+
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.RemoteAddress.IP
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
+import akka.http.scaladsl.server.Directives._
+import akka.stream.scaladsl.Flow
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+import spray.util.Utils
+
+class ProxySupportSpec extends Specification with Specs2RouteTest with ProxySupport {
+
+  trait MockServer extends Scope {
+    def serverResponse(req: HttpRequest) = HttpResponse(entity = req.uri.toRelative.toString)
+
+    val (interface, port) = Utils.temporaryServerHostnameAndPort()
+    Http().bindAndHandle(Flow.fromFunction(serverResponse), interface, port)
+
+    val routes = {
+      // format: OFF
+      (get | post) {
+        path("get-path") {
+          complete("get-reply")
+        } ~
+        path("get-path-proxied") {
+          proxySingleTo(Uri(s"http://$interface:$port/remote-proxy"))
+        } ~
+        pathPrefix("get-path-proxied-unmatched") {
+          proxySingleToUnmatchedPath(Uri(s"http://$interface:$port/remote-proxy"))
+        }
+      }
+      // format: ON
+    }
+  }
+
+  val localIp1 = IP(InetAddress.getByName("127.0.0.1"))
+  val localIp2 = IP(InetAddress.getByName("127.0.0.2"))
+
+  "A proxy support directive" should {
+
+    "proxy requests" in new MockServer {
+      Get("/get-path") ~> routes ~> check {
+        status == OK
+        responseAs[String] must be_==("get-reply")
+      }
+      Get("/get-path-proxied") ~> routes ~> check {
+        status == OK
+        responseAs[String] must be_==("/remote-proxy")
+      }
+      Post("/get-path-proxied") ~> routes ~> check {
+        status == OK
+        responseAs[String] must be_==("/remote-proxy")
+      }
+    }
+
+    "proxy requests using unmatched path" in new MockServer {
+      Get("/get-path") ~> routes ~> check {
+        status == OK
+        responseAs[String] must be_==("get-reply")
+      }
+      Get("/get-path-proxied-unmatched/other/path/parts") ~> routes ~> check {
+        status == OK
+        responseAs[String] must be_==("/remote-proxy/other/path/parts")
+      }
+      Post("/get-path-proxied-unmatched/other/path/parts") ~> routes ~> check {
+        status == OK
+        responseAs[String] must be_==("/remote-proxy/other/path/parts")
+      }
+      Get("/get-path-proxied-unmatched/other/path/parts?foo=bar") ~> routes ~> check {
+        status == OK
+        responseAs[String] must be_==("/remote-proxy/other/path/parts?foo=bar")
+      }
+    }
+
+    "Modify the `X-Forwarded-For` header" in new MockServer {
+
+      override def serverResponse(req: HttpRequest) = {
+        val forwardedForIps = req.headers.collectFirst {
+          case `X-Forwarded-For`(ips) => ips
+        }.getOrElse(Seq.empty)
+        HttpResponse(entity = forwardedForIps.mkString(", "))
+      }
+
+      "add `X-Forwarded-For` if request has `Remote-Address`" in {
+        Get("/get-path-proxied").withHeaders(`Remote-Address`(localIp1)) ~> routes ~> check {
+          status == OK
+          responseAs[String] must be_==("127.0.0.1")
+        }
+      }
+
+      "update existing `X-Forwarded-For`" in {
+        Get("/get-path-proxied").withHeaders(`Remote-Address`(localIp1), `X-Forwarded-For`(localIp2)) ~> routes ~> check {
+          status == OK
+          responseAs[String] must be_==("127.0.0.2, 127.0.0.1")
+        }
+
+        Get("/get-path-proxied").withHeaders(`X-Forwarded-For`(localIp2)) ~> routes ~> check {
+          status == OK
+          responseAs[String] must be_==("127.0.0.2")
+        }
+      }
+
+      "do not add `X-Forwarded-For` if no `Remote-Address`" in {
+        Get("/get-path-proxied") ~> routes ~> check {
+          status == OK
+          responseAs[String] must be_==("a")
+        }
+      }
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -26,7 +26,8 @@ object ProjectBuild extends Build {
       "com.jcraft"                     % "jzlib"                     % "1.1.3",
       "com.twmacinta"                  % "fast-md5"                  % "2.7.1",
       "com.typesafe"                   % "config"                    % "1.3.0"          % "provided",
-      "com.typesafe.akka"             %% "akka-actor"                % "2.4.8"          % "provided",
+      "com.typesafe.akka"             %% "akka-actor"                % "2.4.10"         % "provided",
+      "com.typesafe.akka"             %% "akka-http-experimental"    % "2.4.10"         % "provided",
       "io.github.andrebeat"           %% "scala-pool"                % "0.3.0",
       "io.spray"                      %% "spray-can"                 % "1.3.3"          % "provided",
       "io.spray"                      %% "spray-httpx"               % "1.3.3"          % "provided",
@@ -37,19 +38,21 @@ object ProjectBuild extends Build {
       "org.bouncycastle"               % "bcprov-jdk15on"            % "1.54",
       "org.scalaz"                    %% "scalaz-core"               % "7.2.5"          % "provided",
       "org.slf4j"                      % "slf4j-api"                 % "1.7.21",
+      "com.typesafe.akka"             %% "akka-http-testkit"         % "2.4.10"         % "test",
       "io.spray"                      %% "spray-testkit"             % "1.3.3"          % "test",
+      "junit"                          % "junit"                     % "4.12"           % "test",
+      "org.scalacheck"                %% "scalacheck"                % "1.13.2"         % "test",
       "org.specs2"                    %% "specs2-core"               % "3.8.4"          % "test",
       "org.specs2"                    %% "specs2-scalacheck"         % "3.8.4"          % "test",
-      "org.specs2"                    %% "specs2-junit"              % "3.8.4"          % "test",
-      "junit"                          % "junit"                     % "4.12"           % "test",
-      "org.scalacheck"                %% "scalacheck"                % "1.13.2"         % "test"))
+      "org.specs2"                    %% "specs2-junit"              % "3.8.4"          % "test"))
 
   lazy val apsoTestkit = Project("apso-testkit", file("apso-testkit"))
     .settings(commonSettings: _*)
     .settings(publishSettings: _*)
     .settings(apsoTestkitSettings: _*)
     .settings(libraryDependencies ++= Seq(
-      "com.typesafe.akka"             %% "akka-testkit"       % "2.4.8"          % "provided",
+      "com.typesafe.akka"             %% "akka-testkit"       % "2.4.10"         % "provided",
+      "com.typesafe.akka"             %% "akka-http-testkit"  % "2.4.10"         % "provided",
       "org.slf4j"                      % "slf4j-api"          % "1.7.21",
       "org.specs2"                    %% "specs2-core"        % "3.8.4"          % "provided",
       "org.specs2"                    %% "specs2-junit"       % "3.8.4"          % "provided"


### PR DESCRIPTION
This pull request ports our Spray-based reverse proxy routes to akka-http.