### PR TITLE
Make json.Implicits.fromFullPaths separator customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Apso is ShiftForward's utilities library. It provides a series of useful methods
 
 ## Installation
 
-Apso's latest release is `0.9.0` and is built against Scala 2.11.8.
+Apso's latest release is `0.9.1` and is built against Scala 2.11.8.
 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "eu.shiftforward" %% "apso" % "0.9.0"
+libraryDependencies += "eu.shiftforward" %% "apso" % "0.9.1"
 ```
 
 The TestKit is available under the `apso-testkit` project. You can include it only for the `test` configuration:
 
 ```scala
-libraryDependencies += "eu.shiftforward" %% "apso-testkit" % "0.9.0" % "test"
+libraryDependencies += "eu.shiftforward" %% "apso-testkit" % "0.9.1" % "test"
 ```
 
 Please take into account that the library is still in an experimental stage and the interfaces might change for subsequent releases.

--- a/apso/src/main/scala/eu/shiftforward/apso/json/Implicits.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/json/Implicits.scala
@@ -85,12 +85,13 @@ object Implicits {
   }
 
   /**
-   * Creates a JsObject from a sequence of pairs of dot-separated paths with the corresponding
+   * Creates a JsObject from a sequence of pairs of dot-separated (or other separator) paths with the corresponding
    * leaf values (eg. `List(("root.leaf1", JsString("leafVal1")), ("root.leaf2", JsString("leafVal2")))`
-   * @param paths the sequence of dot-separated paths
+   * @param paths the sequence of dot-separated (or other separator) paths
+   * @param separatorRegex regex to use to separate fields
    * @return the resulting JsObject
    */
-  def fromFullPaths(paths: Seq[(String, JsValue)]): JsValue = {
+  def fromFullPaths(paths: Seq[(String, JsValue)], separatorRegex: String = "\\."): JsValue = {
     def createJsValue(keys: Seq[String], value: JsValue): JsValue = {
       keys match {
         case Nil => value
@@ -101,7 +102,7 @@ object Implicits {
     paths match {
       case Nil => JsObject()
       case (path, value) :: rem =>
-        createJsValue(path.split("\\.").toList, value).merge(fromFullPaths(rem))
+        createJsValue(path.split(separatorRegex).toList, value).merge(fromFullPaths(rem))
     }
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,7 +59,7 @@ object ProjectBuild extends Build {
 
   lazy val commonSettings = Defaults.coreDefaultSettings ++ formatSettings ++ Seq(
     organization := "eu.shiftforward",
-    version := "0.9.0",
+    version := "0.9.1",
     scalaVersion := "2.11.8",
 
     resolvers ++= Seq(


### PR DESCRIPTION
Changes the `json.Implicits.fromFullPaths` method to also accept an optional separator regex, instead of always using `"\\."`.

`"\\."` is still the default value, so this should be a backwards compatible change.