### PR TITLE
Increase proxy support tests timeouts

### DIFF
--- a/apso/src/test/scala/eu/shiftforward/apso/akka/http/ProxySupportSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/akka/http/ProxySupportSpec.scala
@@ -2,9 +2,11 @@ package eu.shiftforward.apso.akka.http
 
 import java.net.InetAddress
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import akka.http.scaladsl.Http
+import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model.RemoteAddress.IP
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers._
@@ -12,17 +14,18 @@ import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.stream.scaladsl.Flow
+import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
 import spray.util.Utils
 
-class ProxySupportSpec extends Specification with Specs2RouteTest with ProxySupport {
+class ProxySupportSpec(implicit ee: ExecutionEnv) extends Specification with Specs2RouteTest with ProxySupport {
 
   trait MockServer extends Scope {
     def serverResponse(req: HttpRequest) = HttpResponse(entity = req.uri.toRelative.toString)
 
     val (interface, port) = Utils.temporaryServerHostnameAndPort()
-    Http().bindAndHandle(Flow.fromFunction(serverResponse), interface, port)
+    val boundFuture: Future[ServerBinding] = Http().bindAndHandle(Flow.fromFunction(serverResponse), interface, port)
 
     val proxy = new Proxy(interface, port)
 
@@ -44,6 +47,8 @@ class ProxySupportSpec extends Specification with Specs2RouteTest with ProxySupp
       }
       // format: ON
     }
+
+    boundFuture.map(_.localAddress.isUnresolved) must beFalse.awaitFor(10.seconds)
   }
 
   val localIp1 = IP(InetAddress.getByName("127.0.0.1"))

--- a/apso/src/test/scala/eu/shiftforward/apso/akka/http/ProxySupportSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/akka/http/ProxySupportSpec.scala
@@ -2,12 +2,15 @@ package eu.shiftforward.apso.akka.http
 
 import java.net.InetAddress
 
+import scala.concurrent.duration._
+
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.RemoteAddress.IP
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.stream.scaladsl.Flow
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
@@ -46,7 +49,9 @@ class ProxySupportSpec extends Specification with Specs2RouteTest with ProxySupp
   val localIp1 = IP(InetAddress.getByName("127.0.0.1"))
   val localIp2 = IP(InetAddress.getByName("127.0.0.2"))
 
-  "A proxy support directive" should {
+  implicit val timeout = RouteTestTimeout(5.seconds)
+
+  "An akka-http proxy support directive" should {
 
     "proxy single requests" in new MockServer {
       Get("/get-path") ~> routes ~> check {

--- a/apso/src/test/scala/eu/shiftforward/apso/spray/ProxySupportSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/spray/ProxySupportSpec.scala
@@ -59,7 +59,9 @@ class ProxySupportSpec
     }
   }
 
-  "A proxy support directive" should {
+  implicit val timeout = RouteTestTimeout(5.seconds)
+
+  "A spray proxy support directive" should {
 
     "proxy requests" in new MockServer {
       Get("/get-path") ~> routes ~> check {


### PR DESCRIPTION
The `ProxySupportSpec`s kept failing remotely due to timeouts.

This PR increases the timeouts of both tests and changes the specification title to make it easier to distinguish the spray proxy results from the akka-http proxy results-