### PR TITLE
InsistentInputStream performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Apso is ShiftForward's utilities library. It provides a series of useful methods
 
 ## Installation
 
-Apso's latest release is `0.9.2` and is built against Scala 2.11.8.
+Apso's latest release is `0.9.3` and is built against Scala 2.11.8.
 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "eu.shiftforward" %% "apso" % "0.9.2"
+libraryDependencies += "eu.shiftforward" %% "apso" % "0.9.3"
 ```
 
 The TestKit is available under the `apso-testkit` project. You can include it only for the `test` configuration:
 
 ```scala
-libraryDependencies += "eu.shiftforward" %% "apso-testkit" % "0.9.2" % "test"
+libraryDependencies += "eu.shiftforward" %% "apso-testkit" % "0.9.3" % "test"
 ```
 
 Please take into account that the library is still in an experimental stage and the interfaces might change for subsequent releases.

--- a/apso/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
@@ -283,10 +283,7 @@ class S3Bucket(
 
   def stream(key: String): InputStream = {
     log.info("Streaming 's3://{}/{}'", bucketName: Any, key: Any)
-    new InsistentInputStream(
-      () => s3.getObject(new GetObjectRequest(bucketName, sanitizeKey(key))).getObjectContent,
-      10,
-      Some(100.milliseconds))
+    s3.getObject(new GetObjectRequest(bucketName, sanitizeKey(key))).getObjectContent
   }
 
   private[this] def handler: PartialFunction[Throwable, Boolean] = {

--- a/apso/src/main/scala/eu/shiftforward/apso/io/InsistentInputStream.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/io/InsistentInputStream.scala
@@ -6,6 +6,8 @@ import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
 
+import eu.shiftforward.apso.Logging
+
 /**
  * A InputStream that wraps another InputStream, retrying failed reads. This is useful for input streams that can have
  * transient failures (eg HTTP input streams).
@@ -14,7 +16,7 @@ import scala.util.{ Failure, Success, Try }
  * @param maxRetries maximum number of times to retry a read
  * @param backoff optional duration to wait between retries
  */
-class InsistentInputStream(streamBuilder: () => InputStream, maxRetries: Int = 10, backoff: Option[FiniteDuration] = None) extends InputStream {
+class InsistentInputStream(streamBuilder: () => InputStream, maxRetries: Int = 10, backoff: Option[FiniteDuration] = None) extends InputStream with Logging {
 
   private[this] var innerStream: InputStream = streamBuilder()
   private[this] var currPos: Long = 0
@@ -36,21 +38,37 @@ class InsistentInputStream(streamBuilder: () => InputStream, maxRetries: Int = 1
   }
 
   @tailrec
-  private[this] def readRetries(remainingTries: Int): Int = {
-    Try(innerStream.read) match {
+  private[this] def readRetries(remainingTries: Int, f: => Int): Int = {
+    Try(f) match {
       case Success(n) =>
-        currPos += 1
         n
       case Failure(t) =>
         if (remainingTries <= 0) throw t
         else {
+          log.warn("Failed to read from stream: {}", t)
           val nextRemainingTries = retryStreamCreation(remainingTries - 1)
-          readRetries(nextRemainingTries)
+          readRetries(nextRemainingTries, f)
         }
     }
   }
 
-  def read(): Int = readRetries(maxRetries)
+  def read(): Int = {
+    val nextByte = readRetries(maxRetries, innerStream.read())
+    if (nextByte > 0) currPos += 1
+    nextByte
+  }
+
+  override def read(b: Array[Byte]): Int = {
+    val bytesRead = readRetries(maxRetries, innerStream.read(b))
+    if (bytesRead > 0) currPos += bytesRead
+    bytesRead
+  }
+
+  override def read(b: Array[Byte], off: Int, len: Int): Int = {
+    val bytesRead = readRetries(maxRetries, innerStream.read(b, off, len))
+    if (bytesRead > 0) currPos += bytesRead
+    bytesRead
+  }
 
   override def available(): Int = innerStream.available()
   override def close() = innerStream.close()

--- a/apso/src/main/scala/eu/shiftforward/apso/io/InsistentInputStream.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/io/InsistentInputStream.scala
@@ -54,7 +54,7 @@ class InsistentInputStream(streamBuilder: () => InputStream, maxRetries: Int = 1
 
   def read(): Int = {
     val nextByte = readRetries(maxRetries, innerStream.read())
-    if (nextByte > 0) currPos += 1
+    if (nextByte >= 0) currPos += 1
     nextByte
   }
 

--- a/apso/src/test/scala/eu/shiftforward/apso/io/InsistentInputStreamSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/io/InsistentInputStreamSpec.scala
@@ -8,7 +8,7 @@ class InsistentInputStreamSpec extends Specification {
 
   "An InsistentInputStream" should {
 
-    val testList = List[Byte](1, 2, 3, 4, 5)
+    val testList = (1 to 100).map(_.toByte)
 
     def testGoodInputStream() = new InputStream {
       val iter = testList.iterator
@@ -19,9 +19,10 @@ class InsistentInputStreamSpec extends Specification {
       var fail = false
       val iter = testList.iterator
       def read(): Int = {
-        if (fail) throw new Exception("bad read")
-        else {
-          fail = true
+        if (fail) {
+          fail = false
+          throw new Exception("bad read")
+        } else {
           iter.next()
         }
       }
@@ -29,6 +30,7 @@ class InsistentInputStreamSpec extends Specification {
         iter.drop(l.toInt)
         l
       }
+      def failNext() = fail = true
     }
 
     def testBadInputStream() = new InputStream {
@@ -39,25 +41,45 @@ class InsistentInputStreamSpec extends Specification {
     "have a working input stream interface" in {
 
       val stream = new InsistentInputStream(testGoodInputStream)
+      val testBuffer = Array[Byte](0, 0, 0)
 
       stream.read() === 1
       stream.read() === 2
       stream.skip(2) === 2
       stream.read() === 5
+      stream.read(testBuffer) === 3
+      testBuffer === Array[Byte](6, 7, 8)
+      stream.skip(1) === 1
+      stream.read() === 10
+      stream.read(testBuffer, 1, 2) === 2
+      testBuffer === Array[Byte](6, 11, 12)
     }
 
     "retry reads when a inner stream is buggy" in {
       val buggyStream = testBuggyInputStream()
 
       buggyStream.read() === 1
+      buggyStream.failNext()
       buggyStream.read() must throwAn[Exception]
 
       val stream = new InsistentInputStream(testBuggyInputStream)
+      val testBuffer = Array[Byte](0, 0, 0)
 
       stream.read() === 1
+      buggyStream.failNext()
       stream.read() === 2
       stream.skip(2) === 2
+      buggyStream.failNext()
       stream.read() === 5
+      buggyStream.failNext()
+      stream.read(testBuffer) === 3
+      testBuffer === Array[Byte](6, 7, 8)
+      stream.skip(1) === 1
+      buggyStream.failNext()
+      stream.read() === 10
+      buggyStream.failNext()
+      stream.read(testBuffer, 1, 2) === 2
+      testBuffer === Array[Byte](6, 11, 12)
     }
 
     "fail after the retry limit is exceeded" in {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,7 +59,7 @@ object ProjectBuild extends Build {
 
   lazy val commonSettings = Defaults.coreDefaultSettings ++ formatSettings ++ Seq(
     organization := "eu.shiftforward",
-    version := "0.9.2",
+    version := "0.9.3",
     scalaVersion := "2.11.8",
 
     resolvers ++= Seq(


### PR DESCRIPTION
The `InsistentInputStream`had some performance problems with bulk reads (it wrapped every Byte read in a `Try`).

This becomes a problem when using `StreamConverters.fromInputStream` from akka-streams, which has a default chunk size of 8192 Bytes.