### PR TITLE
Fix json.Implicits.fromFullPaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Apso is ShiftForward's utilities library. It provides a series of useful methods
 
 ## Installation
 
-Apso's latest release is `0.9.3` and is built against Scala 2.11.8.
+Apso's latest release is `0.9.4` and is built against Scala 2.11.8.
 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "eu.shiftforward" %% "apso" % "0.9.3"
+libraryDependencies += "eu.shiftforward" %% "apso" % "0.9.4"
 ```
 
 The TestKit is available under the `apso-testkit` project. You can include it only for the `test` configuration:
 
 ```scala
-libraryDependencies += "eu.shiftforward" %% "apso-testkit" % "0.9.3" % "test"
+libraryDependencies += "eu.shiftforward" %% "apso-testkit" % "0.9.4" % "test"
 ```
 
 Please take into account that the library is still in an experimental stage and the interfaces might change for subsequent releases.

--- a/apso/src/main/scala/eu/shiftforward/apso/json/Implicits.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/json/Implicits.scala
@@ -102,7 +102,7 @@ object Implicits {
     paths match {
       case Nil => JsObject()
       case (path, value) :: rem =>
-        createJsValue(path.split(separatorRegex).toList, value).merge(fromFullPaths(rem))
+        createJsValue(path.split(separatorRegex).toList, value).merge(fromFullPaths(rem, separatorRegex))
     }
   }
 }

--- a/apso/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/json/ImplicitsSpec.scala
@@ -70,6 +70,20 @@ class ImplicitsSpec extends Specification {
       res mustEqual expected.parseJson
     }
 
+    "provide a method to create a json object from complete paths (with a custom separator)" in {
+      val res = fromFullPaths(
+        List(
+          "a-b-c" -> JsNumber(1),
+          "a-b-d-e" -> JsNumber(3),
+          "a-f" -> JsNumber(5),
+          "g" -> JsNumber(4)), "-")
+
+      val expected =
+        """{ "a": {"b": {"c": 1, "d": {"e": 3}}, "f": 5}, "g": 4 }"""
+
+      res mustEqual expected.parseJson
+    }
+
     "provide a method to get the key set of a JsObject" in {
       val obj = """{"a":1,"b":{"c":2},"d":null}""".parseJson.asJsObject
       obj.flattenedKeySet(".", ignoreNull = true) === Set("a", "b.c")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,7 +59,7 @@ object ProjectBuild extends Build {
 
   lazy val commonSettings = Defaults.coreDefaultSettings ++ formatSettings ++ Seq(
     organization := "eu.shiftforward",
-    version := "0.9.3",
+    version := "0.9.4",
     scalaVersion := "2.11.8",
 
     resolvers ++= Seq(


### PR DESCRIPTION
Commit 99c0066998da603c41b8721fc93068d50015124b introduced a bug on `json.Implicits.fromFullPaths`. The custom separator was not being passed on the recursive call.