### PR TITLE
Change Buffered composite iterator logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Apso is ShiftForward's utilities library. It provides a series of useful methods
 
 ## Installation
 
-Apso's latest release is `0.9.5` and is built against Scala 2.11.8.
+Apso's latest release is `0.9.6` and is built against Scala 2.11.8.
 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "eu.shiftforward" %% "apso" % "0.9.5"
+libraryDependencies += "eu.shiftforward" %% "apso" % "0.9.6"
 ```
 
 The TestKit is available under the `apso-testkit` project. You can include it only for the `test` configuration:
 
 ```scala
-libraryDependencies += "eu.shiftforward" %% "apso-testkit" % "0.9.5" % "test"
+libraryDependencies += "eu.shiftforward" %% "apso-testkit" % "0.9.6" % "test"
 ```
 
 Please take into account that the library is still in an experimental stage and the interfaces might change for subsequent releases.

--- a/apso/src/test/scala/eu/shiftforward/apso/iterator/CompositeIteratorSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/iterator/CompositeIteratorSpec.scala
@@ -20,14 +20,27 @@ class CompositeIteratorSpec extends Specification {
     "apply correctly concatenation (++)" in {
       val cit = CompositeIterator[Int]()
       (cit ++ a1 ++ a2 ++ a3).toList mustEqual concatExpected
-      ok
     }
 
-    "be bufferable" in {
+    "be bufferable (head)" in {
       val cit = (CompositeIterator[Int]() ++ a1 ++ a2 ++ a3).buffered
       cit.head === concatExpected.head
       cit.toList mustEqual concatExpected
-      ok
+    }
+
+    "be bufferable (filter)" in {
+      val cit = (CompositeIterator[Int]() ++ a1 ++ a2 ++ a3).buffered
+      cit.dropWhile(_ < 3).toList mustEqual concatExpected.dropWhile(_ < 3)
+    }
+
+    "be bufferable (takeWhile)" in {
+      val cit = (CompositeIterator[Int]() ++ a1 ++ a2 ++ a3).buffered
+      cit.filter(x => x < 5).toList mustEqual concatExpected.filter(x => x < 5)
+    }
+
+    "be bufferable (dropWhile)" in {
+      val cit = (CompositeIterator[Int]() ++ a1 ++ a2 ++ a3).buffered
+      cit.filter(x => x > 2 && x < 5).toList mustEqual concatExpected.filter(x => x > 2 && x < 5)
     }
 
     "correctly serialize iterators to a single queue" in {

--- a/apso/src/test/scala/eu/shiftforward/apso/iterator/CompositeIteratorSpec.scala
+++ b/apso/src/test/scala/eu/shiftforward/apso/iterator/CompositeIteratorSpec.scala
@@ -23,6 +23,13 @@ class CompositeIteratorSpec extends Specification {
       ok
     }
 
+    "be bufferable" in {
+      val cit = (CompositeIterator[Int]() ++ a1 ++ a2 ++ a3).buffered
+      cit.head === concatExpected.head
+      cit.toList mustEqual concatExpected
+      ok
+    }
+
     "correctly serialize iterators to a single queue" in {
 
       "not create a recursive structure" in {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,7 +59,7 @@ object ProjectBuild extends Build {
 
   lazy val commonSettings = Defaults.coreDefaultSettings ++ formatSettings ++ Seq(
     organization := "eu.shiftforward",
-    version := "0.9.5",
+    version := "0.9.6",
     scalaVersion := "2.11.8",
 
     resolvers ++= Seq(


### PR DESCRIPTION
Some iterators (eg. iterators that use a scratch memory) might have custom logic on their buffered versions that was being ignored by our old composite iterator.

This fixes that by moving the responsibility of storing the head (if needed) to the inner iterators.