### PR TITLE
S3Bucket: when finding files with a matching prefix use debug level logging

### DIFF
--- a/apso/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
@@ -120,7 +120,7 @@ class S3Bucket(
 
     val listings = Iterator.iterate(s3.listObjects(bucketName, sanitizeKey(prefix))) { listing =>
       if (listing.isTruncated) {
-        log.info("Asking for another batch of objects...")
+        log.debug("Asking for another batch of objects...")
         s3.listNextBatchOfObjects(listing)
       } else null
     }


### PR DESCRIPTION
This is a very noisy message that should be logged as debug.