### PR TITLE
Include nscala-time as a transitive dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Apso is ShiftForward's utilities library. It provides a series of useful methods
 
 ## Installation
 
-Apso's latest release is `0.9.7` and is built against Scala 2.11.8.
+Apso's latest release is `0.9.8` and is built against Scala 2.11.8.
 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "eu.shiftforward" %% "apso" % "0.9.7"
+libraryDependencies += "eu.shiftforward" %% "apso" % "0.9.8"
 ```
 
 The TestKit is available under the `apso-testkit` project. You can include it only for the `test` configuration:
 
 ```scala
-libraryDependencies += "eu.shiftforward" %% "apso-testkit" % "0.9.7" % "test"
+libraryDependencies += "eu.shiftforward" %% "apso-testkit" % "0.9.8" % "test"
 ```
 
 Please take into account that the library is still in an experimental stage and the interfaces might change for subsequent releases.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,7 +19,7 @@ object ProjectBuild extends Build {
       "com.amazonaws"                  % "aws-java-sdk-ec2"          % "1.11.38"        % "provided",
       "com.amazonaws"                  % "aws-java-sdk-s3"           % "1.11.38"        % "provided",
       "com.chuusai"                   %% "shapeless"                 % "2.3.2",
-      "com.github.nscala-time"        %% "nscala-time"               % "2.14.0"         % "provided",
+      "com.github.nscala-time"        %% "nscala-time"               % "2.14.0",
       "com.hierynomus"                 % "sshj"                      % "0.17.2",
       "com.j256.simplejmx"             % "simplejmx"                 % "1.12",
       "com.jcraft"                     % "jzlib"                     % "1.1.3",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,7 +59,7 @@ object ProjectBuild extends Build {
 
   lazy val commonSettings = Defaults.coreDefaultSettings ++ formatSettings ++ Seq(
     organization := "eu.shiftforward",
-    version := "0.9.7",
+    version := "0.9.8",
     scalaVersion := "2.11.8",
 
     resolvers ++= Seq(


### PR DESCRIPTION
If someone, for example, imports the implicits for Typesafe configs:

```scala
import eu.shiftforward.apso.config.Implicits._
```

`nscala-time` must be in the classpath, even if no method related to `DateTime` is used. For that reason, `nscala-time` cannot be declared as a `provided` dependency.