### PR TITLE
Akka HTTP reverse proxy remove header

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ Apso is ShiftForward's utilities library. It provides a series of useful methods
 
 ## Installation
 
-Apso's latest release is `0.9.8` and is built against Scala 2.11.8.
+Apso's latest release is `0.9.9` and is built against Scala 2.11.8.
 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "eu.shiftforward" %% "apso" % "0.9.8"
+libraryDependencies += "eu.shiftforward" %% "apso" % "0.9.9"
 ```
 
 The TestKit is available under the `apso-testkit` project. You can include it only for the `test` configuration:
 
 ```scala
-libraryDependencies += "eu.shiftforward" %% "apso-testkit" % "0.9.8" % "test"
+libraryDependencies += "eu.shiftforward" %% "apso-testkit" % "0.9.9" % "test"
 ```
 
 Please take into account that the library is still in an experimental stage and the interfaces might change for subsequent releases.

--- a/apso/src/main/scala/eu/shiftforward/apso/akka/http/ProxySupport.scala
+++ b/apso/src/main/scala/eu/shiftforward/apso/akka/http/ProxySupport.scala
@@ -31,8 +31,8 @@ import eu.shiftforward.apso.Logging
 trait ProxySupport extends ClientIPDirectives {
 
   private[this] def getHeaders(ip: Option[RemoteAddress], headers: List[HttpHeader] = Nil) = {
-    // filter `Host` and `Timeout-Access` headers
-    val hs = headers.filterNot(header => header.is("host") || header.is("timeout-access"))
+    // filter `Host`, `Timeout-Access` and `Remote-Address` headers
+    val hs = headers.filterNot(header => header.is("host") || header.is("timeout-access") || header.is("remote-address"))
     // add `X-Forwarded-For` header
     ip.fold(hs)(addForwardedFor(_, hs))
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,7 +59,7 @@ object ProjectBuild extends Build {
 
   lazy val commonSettings = Defaults.coreDefaultSettings ++ formatSettings ++ Seq(
     organization := "eu.shiftforward",
-    version := "0.9.8",
+    version := "0.9.9",
     scalaVersion := "2.11.8",
 
     resolvers ++= Seq(


### PR DESCRIPTION
This PR updates the `ProxySupport` directive to also filter the `Remote-Address` header before proxying the request, this is necessary because this header cannot be "manually inserted" in requests and akka-http will warn about it.