### PR TITLE
Add deprecation message to ActorMatchers

### DIFF
--- a/apso-testkit/src/main/scala/eu/shiftforward/apso/actor/ActorMatchers.scala
+++ b/apso-testkit/src/main/scala/eu/shiftforward/apso/actor/ActorMatchers.scala
@@ -7,6 +7,7 @@ import org.specs2.mutable.SpecificationLike
 
 import scala.concurrent.duration._
 
+@deprecated("Use https://github.com/ruippeixotog/akka-testkit-specs2 instead")
 trait ActorMatchers extends SpecificationLike {
 
   def receive(msg: Any): Matcher[TestKitBase] = { probe: TestKitBase =>


### PR DESCRIPTION
Adds a deprecation message to `ActorMatchers`, as they are superseeded by the new [akka-testkit-specs2](https://github.com/ruippeixotog/akka-testkit-specs2) library.

Sorry for the shameless plug 🙃 
