### PR TITLE
Add customJsonReader and customJsonWriter methods to JsonFormatBuilder

### DIFF
--- a/core/src/test/scala/eu/shiftforward/apso/json/JsonFormatBuilderSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/json/JsonFormatBuilderSpec.scala
@@ -96,5 +96,24 @@ class JsonFormatBuilderSpec extends Specification {
       Test4(Some(3), None).toJson(jf1) mustEqual """{ "a": 3 }""".parseJson
       Test4(None, None).toJson(jf1) mustEqual """{ }""".parseJson
     }
+
+    "allow using single JSON Readers and JSON Writers" in {
+      val builder = JsonFormatBuilder()
+        .optionalField[Int]("a")
+        .optionalField[String]("b")
+
+      val jr = builder.jsonReader[Test4]({ case a :: b :: HNil => Test4(a, b) })
+
+      """{ "a": 3, "b": "hello" }""".parseJson.convertTo[Test4](jr) mustEqual Test4(Some(3), Some("hello"))
+      """{ "a": 3 }""".parseJson.convertTo[Test4](jr) mustEqual Test4(Some(3), None)
+      """{ "a": 3, "b": null }""".parseJson.convertTo[Test4](jr) mustEqual Test4(Some(3), None)
+      """{ }""".parseJson.convertTo[Test4](jr) mustEqual Test4(None, None)
+
+      val jw = builder.jsonWriter[Test4]({ foo => foo.a :: foo.b :: HNil })
+
+      Test4(Some(3), Some("x")).toJson(jw) mustEqual """{ "a": 3, "b": "x" }""".parseJson
+      Test4(Some(3), None).toJson(jw) mustEqual """{ "a": 3 }""".parseJson
+      Test4(None, None).toJson(jw) mustEqual """{ }""".parseJson
+    }
   }
 }


### PR DESCRIPTION
This PR adds a way to build separate `JsonWriter`s and `JsonReader`s from a `JsonFormatBuilder`.

This is useful when the writer and reader require different implicits.

For example, if your reader required a `Reader` implicit and your writer required a `Writer` implicit, you would have to have both to create the JsonFormat:
```scala
implicit def jsonFormat(implicit r: Reader, w: Writer) = builder.customJsonFormat(...)
```

Now you can do this:
```scala
implicit def jsonReader(implicit r: Reader) = builder.customJsonReader(...)
implicit def jsonWriter(implicit w: Writer) = builder.customJsonWriter(...)
```