### PR TITLE
Feature/retry and trywithresources

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,10 @@ var attempts = 0
 
 scala> def m() = {
      |   attempts += 1
-     |   if(attempts > 5)
-     |       attempts
+     |   if (attempts > 5)
+     |     attempts
      |   else
-     |       throw new Exception()
+     |     throw new Exception()
      | }
      
 scala> println(Retry.retry(10)(m))
@@ -305,22 +305,19 @@ scala> import eu.shiftforward.apso.TryWith
 import eu.shiftforward.apso.TryWith
 
 scala> def buildResource = new Closeable {
-     |     override def toString: String = "good resource"
-     |     def close(): Unit = {
-     |       println("Resource is now Closed")
-     |     }
+     |   override def toString: String = "good resource"
+     |   def close(): Unit = {
+     |     println("Resource is now Closed")
      |   }
+     | }
 
-scala>
-    |   def goodHandler(resource: Closeable) = {
-    |     println(resource)
-    |   }
+scala> def goodHandler(resource: Closeable) = {
+     |   println(resource)
+     | }
 
-scala>
-     |   def badHandler(resource: Closeable) = {
-     |     throw new Exception()
-     |
-  }
+scala> def badHandler(resource: Closeable) = {
+     |   throw new Exception()
+     | }
 
 scala> TryWith(buildResource)(goodHandler)
 good resource

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Success(6)
 
 The `TryWith` object mimics the [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) 
 construct from Java world, or a loan pattern, where a given function can try to use a `Closeable` 
-resource which shall automatically disposed off and closed properly afterwards.
+resource which shall automatically be disposed off and closed properly afterwards.
 
 ```scala
 scala> import java.io.Closeable

--- a/core/src/main/scala/eu/shiftforward/apso/Implicits.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/Implicits.scala
@@ -4,7 +4,7 @@ import scala.annotation.tailrec
 import scala.collection.generic.CanBuildFrom
 import scala.compat.Platform
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.Random
+import scala.util.{ Random, Try }
 
 import eu.shiftforward.apso.iterator.MergedBufferedIterator
 
@@ -565,12 +565,25 @@ object Implicits {
   final implicit class ApsoCloseable[U <: AutoCloseable](val res: U) extends AnyVal {
 
     /**
-     * Uses this resouce and closes it afterwards.
+     * Uses this resource and closes it afterwards.
      * @param f the block of code to execute using this resource
      * @tparam T the return type of the code block.
      * @return the value returned by the code block.
      */
+    @deprecated("This will be removed in a future version. Please use `tryUse()` instead", "2017/10/31")
     def use[T](f: U => T): T =
       try { f(res) } finally { res.close() }
+
+    /**
+     * Uses this resource and closes it afterwards.
+     *
+     * Any exception thrown by the code block or during the call to `close()` of the `AutoCloseable` resource
+     * is caught and presented as a `Failure` in return value.
+     *
+     * @param f the block of code to execute using this resource
+     * @tparam T the return type of the code block.
+     * @return a `Try` of the value returned by the code block.
+     */
+    def tryUse[T](f: U => T): Try[T] = TryWith(res)(f)
   }
 }

--- a/core/src/main/scala/eu/shiftforward/apso/Implicits.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/Implicits.scala
@@ -570,9 +570,7 @@ object Implicits {
      * @tparam T the return type of the code block.
      * @return the value returned by the code block.
      */
-    @deprecated("This will be removed in a future version. Please use `tryUse()` instead", "2017/10/31")
-    def use[T](f: U => T): T =
-      try { f(res) } finally { res.close() }
+    def use[T](f: U => T): T = TryWith(res)(f).get
 
     /**
      * Uses this resource and closes it afterwards.

--- a/core/src/main/scala/eu/shiftforward/apso/Retry.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/Retry.scala
@@ -1,9 +1,11 @@
 package eu.shiftforward.apso
 
+import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success, Try }
 
 /**
- * Utility object for retrying Future a number of times.
+ * Utility object with retry mechanisms.
  */
 object Retry {
 
@@ -17,6 +19,7 @@ object Retry {
    * @tparam T the type of what the future completes with
    * @return the resulting `f` function
    */
+  @deprecated("This will be removed in a future version. Please use `retryFuture()` instead", "2017/10/31")
   def apply[T](
     maxRetries: Int = 10,
     inBetweenSleep: Option[Long] = Some(100))(f: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
@@ -28,7 +31,56 @@ object Retry {
         f recoverWith {
           case _ =>
             inBetweenSleep.foreach(Thread.sleep)
-            apply(maxRetries - 1, inBetweenSleep)(f)
+            apply[T](maxRetries - 1, inBetweenSleep)(f)
+        }
+    }
+  }
+
+  /**
+   * Tries to perform a Future[T] until it succeeds or until maximum retries is reached.
+   *
+   * @param maxRetries the number of retries, 10 by default
+   * @param inBetweenSleep the duration to wait between attempts, 100 milliseconds by default
+   * @param f the function that returns the Future[T]
+   * @param ec the implicit execution context
+   * @tparam T the type of what the future completes with
+   * @return the Future[T]
+   */
+  def retryFuture[T](
+    maxRetries: Int = 10,
+    inBetweenSleep: Option[FiniteDuration] = Some(100.millis))(f: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+    maxRetries match {
+      case 0 =>
+        f
+      case _ =>
+        f recoverWith {
+          case _: Throwable =>
+            inBetweenSleep.foreach(d => Thread.sleep(d.toMillis))
+            retryFuture[T](maxRetries - 1, inBetweenSleep)(f)
+        }
+    }
+  }
+
+  /**
+   * Tries to perform a function `f` until it succeeds or until maximum retries is reached.
+   *
+   * @param maxRetries the number of retries, 10 by default
+   * @param inBetweenSleep the duration to wait between attempts, 100 milliseconds by default
+   * @param f the function
+   * @tparam T the type of what the function returns
+   * @return a Try of the `f` function result
+   */
+  def retry[T](
+    maxRetries: Int = 10,
+    inBetweenSleep: Option[FiniteDuration] = Some(100.millis))(f: => T): Try[T] = {
+    maxRetries match {
+      case 0 => Try(f)
+      case _ =>
+        Try(f) match {
+          case res @ Success(_) => res
+          case Failure(_) =>
+            inBetweenSleep.foreach(d => Thread.sleep(d.toMillis))
+            retry[T](maxRetries - 1, inBetweenSleep)(f)
         }
     }
   }

--- a/core/src/main/scala/eu/shiftforward/apso/Retry.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/Retry.scala
@@ -23,17 +23,7 @@ object Retry {
   def apply[T](
     maxRetries: Int = 10,
     inBetweenSleep: Option[Long] = Some(100))(f: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
-
-    maxRetries match {
-      case 0 =>
-        f
-      case _ =>
-        f recoverWith {
-          case _ =>
-            inBetweenSleep.foreach(Thread.sleep)
-            apply[T](maxRetries - 1, inBetweenSleep)(f)
-        }
-    }
+    retryFuture(maxRetries, inBetweenSleep.map(_.millis))(f)
   }
 
   /**

--- a/core/src/main/scala/eu/shiftforward/apso/TryWith.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/TryWith.scala
@@ -1,0 +1,32 @@
+package eu.shiftforward.apso
+
+import java.io.Closeable
+
+import scala.util.control.NonFatal
+import scala.util.{ Failure, Try }
+
+// This is a transcript from https://codereview.stackexchange.com/a/115767/67025
+/**
+ * Mimics the try-with-resource construct from Java world, or a loan pattern, where a given function can try to use a
+ * Closeable resource which shall be disposed off and closed properly afterwards.
+ */
+object TryWith {
+  def apply[C <: Closeable, R](resource: => C)(f: C => R): Try[R] = {
+    Try(resource).flatMap(resourceInstance => {
+      try {
+        val returnValue = f(resourceInstance)
+        Try(resourceInstance.close()).map(_ => returnValue)
+      } catch {
+        case NonFatal(exceptionInFunction) =>
+          try {
+            resourceInstance.close()
+            Failure(exceptionInFunction)
+          } catch {
+            case NonFatal(exceptionInClose) =>
+              exceptionInFunction.addSuppressed(exceptionInClose)
+              Failure(exceptionInFunction)
+          }
+      }
+    })
+  }
+}

--- a/core/src/main/scala/eu/shiftforward/apso/TryWith.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/TryWith.scala
@@ -1,7 +1,5 @@
 package eu.shiftforward.apso
 
-import java.io.Closeable
-
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Try }
 
@@ -11,7 +9,7 @@ import scala.util.{ Failure, Try }
  * Closeable resource which shall be disposed off and closed properly afterwards.
  */
 object TryWith {
-  def apply[C <: Closeable, R](resource: => C)(f: C => R): Try[R] = {
+  def apply[C <: AutoCloseable, R](resource: => C)(f: C => R): Try[R] = {
     Try(resource).flatMap(resourceInstance => {
       try {
         val returnValue = f(resourceInstance)

--- a/core/src/main/scala/eu/shiftforward/apso/io/LocalFileDescriptor.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/io/LocalFileDescriptor.scala
@@ -183,7 +183,7 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
    */
   def write(str: String): Unit = {
     parent().mkdirs()
-    new FileWriter(path).use(_.write(str))
+    new FileWriter(path).tryUse(_.write(str))
   }
 
   /**

--- a/core/src/test/scala/eu/shiftforward/apso/TryWithSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/TryWithSpec.scala
@@ -1,0 +1,70 @@
+package eu.shiftforward.apso
+
+import java.io.Closeable
+
+import scala.util.{ Failure, Success }
+
+import org.specs2.mutable.Specification
+
+// Based on: https://codereview.stackexchange.com/a/115767/67025
+class TryWithSpec extends Specification {
+
+  // Exceptions and errors here so we don't pay the stack trace creation cost multiple times
+  val getResourceException = new RuntimeException
+  val inFunctionException = new RuntimeException
+  val inCloseException = new RuntimeException
+  val getResourceError = new OutOfMemoryError
+  val inFunctionError = new OutOfMemoryError
+  val inCloseError = new OutOfMemoryError
+
+  val goodResource = new Closeable {
+    override def toString: String = "good resource"
+    def close(): Unit = {}
+  }
+
+  "TryWith" should {
+    "catch exceptions getting the resource" in {
+      TryWith(throw getResourceException)(println) must beEqualTo(Failure(getResourceException))
+    }
+
+    "catch exceptions in the function" in {
+      TryWith(goodResource)(_ => throw inFunctionException) must beEqualTo(Failure(inFunctionException))
+    }
+
+    "catch exceptions while closing" in {
+      TryWith(new Closeable {
+        def close(): Unit = throw inCloseException
+      })(_.toString) must beEqualTo(Failure(inCloseException))
+    }
+
+    "note suppressed exceptions" in {
+      val ex = new RuntimeException
+      val result = TryWith(new Closeable {
+        def close(): Unit = throw inCloseException
+      })(_ => throw ex)
+
+      result must beEqualTo(Failure(ex))
+
+      val Failure(returnedException) = result
+      returnedException.getSuppressed must beEqualTo(Array(inCloseException))
+    }
+
+    "propagate errors getting the resource" in {
+      TryWith(throw getResourceError)(println) must throwAn(getResourceError)
+    }
+
+    "propagate errors in the function" in {
+      TryWith(goodResource)(_ => throw inFunctionError) must throwAn(inFunctionError)
+    }
+
+    "propagate errors while closing" in {
+      TryWith(new Closeable {
+        def close(): Unit = throw inCloseError
+      })(_.toString) must throwAn(inCloseError)
+    }
+
+    "return the value from a successful run" in {
+      TryWith(goodResource)(_.toString) must beEqualTo(Success("good resource"))
+    }
+  }
+}

--- a/core/src/test/scala/eu/shiftforward/apso/TryWithSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/TryWithSpec.scala
@@ -43,10 +43,10 @@ class TryWithSpec extends Specification {
         def close(): Unit = throw inCloseException
       })(_ => throw ex)
 
-      result must beEqualTo(Failure(ex))
-
-      val Failure(returnedException) = result
-      returnedException.getSuppressed must beEqualTo(Array(inCloseException))
+      result must beAFailedTry.which { returnedException =>
+        returnedException mustEqual ex
+        returnedException.getSuppressed must beEqualTo(Array(inCloseException))
+      }
     }
 
     "propagate errors getting the resource" in {


### PR DESCRIPTION
Adds new retry mechanisms and a new `TryWith` utility to mimic the `try-with-resources` construct: https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html