### PR TITLE
Add skip parameter to the InsistentInputStream streamBuilder

### DIFF
--- a/core/src/main/scala/eu/shiftforward/apso/io/InsistentInputStream.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/io/InsistentInputStream.scala
@@ -12,13 +12,22 @@ import eu.shiftforward.apso.Logging
  * A InputStream that wraps another InputStream, retrying failed reads. This is useful for input streams that can have
  * transient failures (eg HTTP input streams).
  *
- * @param streamBuilder function that returns a new stream.
+ * @param streamBuilder function that returns a new stream starting at a certain position.
  * @param maxRetries maximum number of times to retry a read
  * @param backoff optional duration to wait between retries
  */
-class InsistentInputStream(streamBuilder: () => InputStream, maxRetries: Int = 10, backoff: Option[FiniteDuration] = None) extends InputStream with Logging {
+class InsistentInputStream(streamBuilder: (Long) => InputStream, maxRetries: Int = 10, backoff: Option[FiniteDuration] = None) extends InputStream with Logging {
 
-  private[this] var innerStream: InputStream = streamBuilder()
+  def this(streamBuilder: () => InputStream, maxRetries: Int, backoff: Option[FiniteDuration]) =
+    this({ x => val is = streamBuilder(); is.skip(x); is }, maxRetries, backoff)
+
+  def this(streamBuilder: () => InputStream, maxRetries: Int) =
+    this({ x => val is = streamBuilder(); is.skip(x); is }, maxRetries)
+
+  def this(streamBuilder: () => InputStream) =
+    this({ x => val is = streamBuilder(); is.skip(x); is })
+
+  private[this] var innerStream: InputStream = streamBuilder(0)
   private[this] var currPos: Long = 0
 
   @tailrec
@@ -26,8 +35,7 @@ class InsistentInputStream(streamBuilder: () => InputStream, maxRetries: Int = 1
     Try(innerStream.close()) // continue even if the close operation fails
     Try {
       backoff.foreach(d => Thread.sleep(d.toMillis))
-      innerStream = streamBuilder()
-      innerStream.skip(currPos)
+      innerStream = streamBuilder(currPos)
     } match {
       case Success(n) =>
         remainingTries


### PR DESCRIPTION
Changes the `streamBuilder` function accepted by the `InsistentInputStream` to be a `(skip: Long) => InputStream` function.

This allows us to create more efficient input streams in some cases where the inner input stream cannot skip efficiently, but can be created with an initial offset. For example, to stream data from an HTTP URL:

```scala
def stream(url: String): InputStream = {
  val builder = (skip: Long) => {
    val connection = new URI(url).toURL.openConnection().asInstanceOf[HttpURLConnection]
    if (skip > 0) connection.setRequestProperty("Range","bytes="+skip+"-")
    connection.getInputStream
  }
  new InsistentInputStream(builder)
}
```