### PR TITLE
Add an offset parameter to the FileDescriptor#stream operation

### DIFF
--- a/core/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/aws/S3Bucket.scala
@@ -280,9 +280,12 @@ class S3Bucket(
     outputStream.close()
   }.isDefined
 
-  def stream(key: String): InputStream = {
-    log.info("Streaming 's3://{}/{}'", bucketName: Any, key: Any)
-    s3.getObject(new GetObjectRequest(bucketName, sanitizeKey(key))).getObjectContent
+  def stream(key: String, offset: Long = 0L): InputStream = {
+    log.info("Streaming 's3://{}/{}' starting at {}", bucketName, key, offset.toString)
+    val req =
+      if (offset > 0) new GetObjectRequest(bucketName, sanitizeKey(key)).withRange(offset)
+      else new GetObjectRequest(bucketName, sanitizeKey(key))
+    s3.getObject(req).getObjectContent
   }
 
   private[this] def handler: PartialFunction[Throwable, Boolean] = {

--- a/core/src/main/scala/eu/shiftforward/apso/io/FileDescriptor.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/io/FileDescriptor.scala
@@ -61,9 +61,10 @@ trait FileDescriptor {
 
   /**
    * Returns an input stream for the contents of this file.
+   * @param offset bytes to skip before reading the file.
    * @return an input stream for the contents of this file.
    */
-  def stream(): InputStream
+  def stream(offset: Long = 0L): InputStream
 
   /**
    * Returns an iterator with the lines of this file.

--- a/core/src/main/scala/eu/shiftforward/apso/io/LocalFileDescriptor.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/io/LocalFileDescriptor.scala
@@ -116,7 +116,11 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
     }
   }
 
-  def stream() = new FileInputStream(file)
+  def stream(offset: Long = 0L) = {
+    val is = new FileInputStream(file)
+    if (offset > 0L) is.skip(offset)
+    is
+  }
 
   override def list: Iterator[LocalFileDescriptor] = {
     if (isDirectory) {

--- a/core/src/main/scala/eu/shiftforward/apso/io/S3FileDescriptor.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/io/S3FileDescriptor.scala
@@ -67,7 +67,7 @@ case class S3FileDescriptor(
     }
   }
 
-  def stream() = bucket.stream(builtPath)
+  def stream(offset: Long = 0L) = bucket.stream(builtPath, offset)
 
   override def cd(pathString: String): S3FileDescriptor = {
     val newPath = pathString.split("/").map(_.trim).toList.foldLeft(elements) {

--- a/core/src/main/scala/eu/shiftforward/apso/io/SftpFileDescriptor.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/io/SftpFileDescriptor.scala
@@ -169,11 +169,12 @@ case class SftpFileDescriptor(
       Try(sftp(_.put(sourceFile, path))).isSuccess
   }
 
-  def stream() = new InputStream {
+  def stream(offset: Long = 0L) = new InputStream {
     private[this] val sftpLease = sftpClient()
     private[this] val sftp = sftpLease.get()
     private[this] val remoteFile = sftp.open(path)
     private[this] val inner = new remoteFile.RemoteFileInputStream()
+    if (offset > 0) inner.skip(offset)
 
     def read() = inner.read()
 

--- a/core/src/test/scala/eu/shiftforward/apso/io/LocalFileDescriptorSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/io/LocalFileDescriptorSpec.scala
@@ -187,7 +187,10 @@ class LocalFileDescriptorSpec extends Specification {
     "Stream a file as bytes or lines" in {
       val fd1 = LocalFileDescriptor("/tmp") / randomFolder / randomString
       fd1.write("1\n2\n3\n4")
+
       Source.fromInputStream(fd1.stream()).mkString === "1\n2\n3\n4"
+      Source.fromInputStream(fd1.stream(2)).mkString === "2\n3\n4"
+
       fd1.lines().toList === List("1", "2", "3", "4")
     }
 


### PR DESCRIPTION
Adds an offset parameter to the stream operation.

This makes it easier to retry downloads without redownloading the whole file, while addressing some problematic `skip` implementations. 