### PR TITLE
Add strict methods to the ProxySupport

### DIFF
--- a/core/src/main/scala/eu/shiftforward/apso/akka/http/ProxySupport.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/akka/http/ProxySupport.scala
@@ -105,7 +105,7 @@ trait ProxySupport extends ClientIPDirectives {
    * @param timeout maximum time to wait for the full response.
    * @return a route that handles requests by proxying them to the given URI.
    */
-  def proxySingleToStrict(uri: Uri, timeout: FiniteDuration): Route = proxy(Some(timeout)) {
+  def strictProxySingleTo(uri: Uri, timeout: FiniteDuration): Route = proxy(Some(timeout)) {
     case (ip, ctx) => ctx.request.copy(
       uri = uri,
       headers = getHeaders(ip, ctx.request.headers.toList))
@@ -120,7 +120,7 @@ trait ProxySupport extends ClientIPDirectives {
    * @param timeout maximum time to wait for the full response.
    * @return a route that handles requests by proxying them to the given URI.
    */
-  def proxySingleToUnmatchedPathStrict(uri: Uri, timeout: FiniteDuration): Route = proxy(Some(timeout)) {
+  def strictProxySingleToUnmatchedPath(uri: Uri, timeout: FiniteDuration): Route = proxy(Some(timeout)) {
     case (ip, ctx) => ctx.request.copy(
       uri = uri.withPath(uri.path ++ ctx.unmatchedPath).withQuery(ctx.request.uri.query()),
       headers = getHeaders(ip, ctx.request.headers.toList))

--- a/core/src/test/scala/eu/shiftforward/apso/akka/http/ProxySupportSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/akka/http/ProxySupportSpec.scala
@@ -39,8 +39,14 @@ class ProxySupportSpec(implicit ee: ExecutionEnv) extends Specification with Spe
         path("get-path") {
           complete("get-reply")
         } ~
+        path("get-path-proxied-single-strict") {
+          proxySingleToStrict(Uri(s"http://$interface:$port/remote-proxy"), 10.seconds)
+        } ~
         path("get-path-proxied-single") {
           proxySingleTo(Uri(s"http://$interface:$port/remote-proxy"))
+        } ~
+        pathPrefix("get-path-proxied-single-unmatched-strict") {
+          proxySingleToUnmatchedPathStrict(Uri(s"http://$interface:$port/remote-proxy"), 10.seconds)
         } ~
         pathPrefix("get-path-proxied-single-unmatched") {
           proxySingleToUnmatchedPath(Uri(s"http://$interface:$port/remote-proxy"))
@@ -67,11 +73,21 @@ class ProxySupportSpec(implicit ee: ExecutionEnv) extends Specification with Spe
         status == OK
         responseAs[String] must be_==("get-reply")
       }
+
       Get("/get-path-proxied-single") ~> routes ~> check {
         status == OK
         responseAs[String] must be_==("/remote-proxy")
       }
       Post("/get-path-proxied-single") ~> routes ~> check {
+        status == OK
+        responseAs[String] must be_==("/remote-proxy")
+      }
+
+      Get("/get-path-proxied-single-strict") ~> routes ~> check {
+        status == OK
+        responseAs[String] must be_==("/remote-proxy")
+      }
+      Post("/get-path-proxied-single-strict") ~> routes ~> check {
         status == OK
         responseAs[String] must be_==("/remote-proxy")
       }
@@ -82,6 +98,7 @@ class ProxySupportSpec(implicit ee: ExecutionEnv) extends Specification with Spe
         status == OK
         responseAs[String] must be_==("get-reply")
       }
+
       Get("/get-path-proxied-single-unmatched/other/path/parts") ~> routes ~> check {
         status == OK
         responseAs[String] must be_==("/remote-proxy/other/path/parts")
@@ -91,6 +108,19 @@ class ProxySupportSpec(implicit ee: ExecutionEnv) extends Specification with Spe
         responseAs[String] must be_==("/remote-proxy/other/path/parts")
       }
       Get("/get-path-proxied-single-unmatched/other/path/parts?foo=bar") ~> routes ~> check {
+        status == OK
+        responseAs[String] must be_==("/remote-proxy/other/path/parts?foo=bar")
+      }
+
+      Get("/get-path-proxied-single-unmatched-strict/other/path/parts") ~> routes ~> check {
+        status == OK
+        responseAs[String] must be_==("/remote-proxy/other/path/parts")
+      }
+      Post("/get-path-proxied-single-unmatched-strict/other/path/parts") ~> routes ~> check {
+        status == OK
+        responseAs[String] must be_==("/remote-proxy/other/path/parts")
+      }
+      Get("/get-path-proxied-single-unmatched-strict/other/path/parts?foo=bar") ~> routes ~> check {
         status == OK
         responseAs[String] must be_==("/remote-proxy/other/path/parts?foo=bar")
       }


### PR DESCRIPTION
For some unknown reason, Akka-HTTP can sometimes leaks long open connections from the connection pool.

This PR adds new `Strict` methods that avoid this problem.