### PR TITLE
Add `Proxy.sendRequest` method

### DIFF
--- a/core/src/main/scala/eu/shiftforward/apso/akka/http/ProxySupport.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/akka/http/ProxySupport.scala
@@ -172,7 +172,7 @@ trait ProxySupport extends ClientIPDirectives {
      * Sends a manually crafted request to a destination URI.
      *
      * @param req the HTTP Request
-     * @param failOnDrop if the future should fail when the message is droped, or complete with a 503
+     * @param failOnDrop if the future should fail when the message is dropped, or complete with a 503
      * @return the request result.
      */
     def sendRequest(req: HttpRequest, failOnDrop: Boolean): Future[RouteResult] = {
@@ -183,7 +183,7 @@ trait ProxySupport extends ClientIPDirectives {
         case QueueClosed => Future.failed(new RuntimeException("Queue is completed before call!?"))
         case Dropped =>
           log.warn("Request queue for {}:{} is full", host, port)
-          if (failOnDrop) Future.failed(new RuntimeException("Droping request (Queue is full)"))
+          if (failOnDrop) Future.failed(new RuntimeException("Dropping request (Queue is full)"))
           else Future.successful(Complete(HttpResponse(StatusCodes.ServiceUnavailable)))
       }
     }

--- a/core/src/test/scala/eu/shiftforward/apso/akka/http/ProxySupportSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/akka/http/ProxySupportSpec.scala
@@ -1,17 +1,18 @@
 package eu.shiftforward.apso.akka.http
 
 import java.net.{ InetAddress, ServerSocket }
-import java.nio.charset.Charset
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
+import akka.NotUsed
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.RemoteAddress.IP
 import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, Uri }
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.RouteResult
 import akka.http.scaladsl.server.RouteResult.Complete
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.stream.scaladsl.Flow
@@ -32,7 +33,14 @@ class ProxySupportSpec(implicit ee: ExecutionEnv) extends Specification with Spe
     }
 
     val (interface, port) = ("localhost", availablePort())
-    val boundFuture = Http().bindAndHandle(Flow.fromFunction(serverResponse), interface, port)
+
+    // Server that replies with the request relative URI and ignores DELETE requests
+    val boundFuture = {
+      val serverFlow: Flow[HttpRequest, HttpResponse, NotUsed] = Flow.apply[HttpRequest]
+        .filter(_.method != HttpMethods.DELETE)
+        .map(serverResponse)
+      Http().bindAndHandle(serverFlow, interface, port)
+    }
 
     val proxy = new Proxy(interface, port)
     val strictProxy = new Proxy(interface, port, strictTimeout = Some(10.seconds))
@@ -157,13 +165,25 @@ class ProxySupportSpec(implicit ee: ExecutionEnv) extends Specification with Spe
         responseAs[String] must be_==("/remote-proxy")
       }
 
-      proxy.sendRequest(Get("/proxied"), failOnDrop = false).flatMap {
-        case Complete(res) => res.entity.toStrict(10.seconds).map { r =>
-          val charset = r.contentType.charsetOption.map(_.nioCharset()).getOrElse(Charset.forName("UTF-8"))
-          r.data.decodeString(charset)
-        }
+      def parseResult(result: RouteResult): Future[String] = result match {
+        case Complete(res) if res.status.intValue() == 200 =>
+          res.entity.toStrict(10.seconds).map { r => r.data.utf8String }
+        case Complete(res) => Future.successful(res.status.intValue().toString)
         case _ => Future.failed(new Exception("Failed to parse result"))
-      } must be_==("/proxied").awaitFor(10.seconds)
+      }
+
+      proxy.sendRequest(Get("/proxied"), failOnDrop = false)
+        .flatMap(parseResult) must be_==("/proxied").awaitFor(10.seconds)
+
+      val badProxy = new Proxy(interface, port, reqQueueSize = 1)
+      // Fill the bad proxy
+      (0 to 10).foreach(x => badProxy.sendRequest(Delete("/proxied-" + x), failOnDrop = false))
+
+      badProxy.sendRequest(Get("/proxied"), failOnDrop = true)
+        .failed.map(_.getMessage) must be_==("Dropping request (Queue is full)").awaitFor(10.seconds)
+
+      badProxy.sendRequest(Get("/proxied"), failOnDrop = false)
+        .flatMap(parseResult) must be_==("503").awaitFor(10.seconds)
     }
 
     "Modify the `X-Forwarded-For` header" in new MockServer {


### PR DESCRIPTION
Adds a `Proxy.sendRequest` method that allows us to send manual requests through the proxy.

This is useful to create health checks that test both the proxy and the final server.