### PR TITLE
Custom JSON error handling

### DIFF
--- a/core/src/main/scala/eu/shiftforward/apso/json/JsonFormatBuilder.scala
+++ b/core/src/main/scala/eu/shiftforward/apso/json/JsonFormatBuilder.scala
@@ -129,8 +129,7 @@ case class JsonFormatBuilder[C <: HList, FC <: HList](fields: FC)(implicit aux: 
    */
   def customJsonReader[A](preRead: JsObject => JsObject, readFunc: ReadFunc[A], errorHandler: (JsValue, Throwable) => A = defaultErrorHandler): RootJsonReader[A] = new RootJsonReader[A] {
     def read(json: JsValue): A = {
-      val jsObject = preRead(json.asJsObject)
-      Try(aux.read(jsObject.fields, fields)) match {
+      Try(aux.read(preRead(json.asJsObject).fields, fields)) match {
         case Success(x) => readFunc(x)
         case Failure(t) => errorHandler(json, t)
       }

--- a/core/src/test/scala/eu/shiftforward/apso/json/JsonFormatBuilderSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/json/JsonFormatBuilderSpec.scala
@@ -129,11 +129,16 @@ class JsonFormatBuilderSpec extends Specification {
         { case a :: b :: c :: HNil => Test(a, b, c) },
         { test: Test => test.a :: test.b.tail :: test.c :: HNil },
         { (_: Test, obj: JsObject) => JsObject((obj.fields + ("c" -> 1.5.toJson)).toList: _*) },
-        (_: JsValue, _: Throwable) => throw new Exception("Caught error!"))
+        (json: JsValue, _: Throwable) =>
+          json match {
+            case JsString(str) => Test(0, List(str), 0.0)
+            case _ => throw new Exception("Caught error!")
+          })
 
       """{ "a": 3, "b": ["x", "y"], "c": 3.0 }""".parseJson.convertTo[Test](jf) mustEqual Test(0, List("x", "y"), 3.0)
       Test(0, List("x", "y"), 3.0).toJson(jf) mustEqual """{ "a": 0, "b": ["y"], "c": 1.5 }""".parseJson
       Try("""{ "a": "asd" }""".parseJson.convertTo[Test](jf)) must beFailedTry.withThrowable[Exception]("Caught error!")
+      """"string"""".parseJson.convertTo[Test](jf) mustEqual Test(0, List("string"), 0.0)
     }
   }
 }

--- a/core/src/test/scala/eu/shiftforward/apso/json/JsonFormatBuilderSpec.scala
+++ b/core/src/test/scala/eu/shiftforward/apso/json/JsonFormatBuilderSpec.scala
@@ -134,7 +134,6 @@ class JsonFormatBuilderSpec extends Specification {
       """{ "a": 3, "b": ["x", "y"], "c": 3.0 }""".parseJson.convertTo[Test](jf) mustEqual Test(0, List("x", "y"), 3.0)
       Test(0, List("x", "y"), 3.0).toJson(jf) mustEqual """{ "a": 0, "b": ["y"], "c": 1.5 }""".parseJson
       Try("""{ "a": "asd" }""".parseJson.convertTo[Test](jf)) must beFailedTry.withThrowable[Exception]("Caught error!")
-
     }
   }
 }


### PR DESCRIPTION
Adds a `errorHandler: (JsValue, Throwable) => A` field to the  `JsonFormatBuilder.customJsonFormat`.

This allows us to recover some errors or add context to some error messages.

I also needed to add two type aliases:
```scala
type ReadFunc[+A] = C => A
type WriteFunc[-A] = A => C
```

This is helpful to drop the `C` in helper functions such as:
```scala
// Without type aliases
def myJsonFormat[C <: HList, A](builder: JsonFormatBuilder[C, _ <: HList])(read: C => A, write: A => C): RootJsonFormat[A]

// With type aliases
def myJsonFormat[A](builder: JsonFormatBuilder[_ <: HList, _ <: HList])(read: builder.ReadFunc[A], write: builder.WriteFunc[A]): RootJsonFormat[A]
```
which is much easier to call, as you usually need to define `A` manually when calling this function.
